### PR TITLE
Expose RRuleParseError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,7 +263,7 @@ mod rruleset_iter;
 mod rrulestr;
 mod utils;
 
-pub use crate::options::{Frequenzy, NWeekday, Options, ParsedOptions};
+pub use crate::options::{Frequenzy, NWeekday, Options, ParsedOptions, RRuleParseError};
 pub use crate::rrule::RRule;
 pub use crate::rruleset::RRuleSet;
 pub use chrono::Weekday;


### PR DESCRIPTION
I was trying to wrap the parsing error in my own error enum, when I noticed that I couldn't. This is just a quick fix assuming there's no reason to keep the `RRuleParseError` private.