### PR TITLE
Add `DateFilter` trait and moved functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ This project follows the [Semantic Versioning standard](https://semver.org/).
 (only used internally and for debugging)
 - Added `examples` folder and moved some code from documentation into examples.
 - New and improved error handling consolidated into one object, `RRuleError`.
-- Added new method to `RRule` and `RRuleSet`: `all_with_error`, similar to `all` but
-returns all dates it could get until it encountered an error.
+- Added new trait `DateFilter` for implementing methods like:
+`all_with_error`, `all_before_with_error`, `all_after_with_error` and `all_between_with_error` and moved/added methods like `all`, `just_before`, etc.
 - Added arbitrary limits for safety reasons.
 See [ReadMe](README.md#validation_limits) for more info.
 - Improved `rrule` command line tool.
@@ -30,6 +30,7 @@ See [ReadMe](README.md#validation_limits) for more info.
 - `RRuleIter` and `RRuleSetIter` are now part of the public API.
 - `NWeekday` has totally changed, but serves the same purpose.
 - Updated `chrono-tz` from `0.5.3` to `0.6.0`.
+- Function `all` was moved to `DateFilter` and returns a `Result` now.
 
 ### Deprecated
 
@@ -40,6 +41,9 @@ See [ReadMe](README.md#validation_limits) for more info.
 - `by_n_weekday` field removed from `ParsedOptions`, combined into `by_weekday`.
 - `concat` and `build` in `Options` are removed, no longer needed.
 - Removed `serde` dependency. (#21)
+- Removed function `between`, use `DateFilter::all_between` instead.
+- Removed function `after`, use `DateFilter::just_after` instead.
+- Removed function `before`, use `DateFilter::just_before` instead.
 
 ### Fixed
 - Replaced panic on incorrect datetime with error.

--- a/README.md
+++ b/README.md
@@ -53,9 +53,7 @@ let rrule: RRule = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=3".parse().
 // Set hard limit in case of infinitely recurring rules.
 let limit = 100;
 // Get all recurrences of the rrule
-let recurrences = rrule.all(limit);
-// Or rrule.into_iter().take(limit as usize).collect::<Vec<_>>();
-// if you want to leverage the iterator directly
+let recurrences = rrule.all(limit).unwrap();
 assert_eq!(recurrences.len(), 3);
 ```
 

--- a/rrule-afl-fuzz/src/main.rs
+++ b/rrule-afl-fuzz/src/main.rs
@@ -5,7 +5,7 @@ use take_rrule::take_rrule_from_data;
 
 use afl::fuzz;
 use core::str::FromStr;
-use rrule::{RRule, RRuleSet};
+use rrule::{DateFilter, RRule, RRuleSet};
 
 #[allow(clippy::single_match)]
 fn main() {

--- a/rrule-debugger/Cargo.toml
+++ b/rrule-debugger/Cargo.toml
@@ -13,6 +13,8 @@ chrono = "0.4.19"
 chrono-tz = "0.6.0"
 structopt = "0.3.23"
 rrule-afl-fuzz = { version = "0.1.0", path = "../rrule-afl-fuzz" }
+log = "0.4.14"
+yansi = "0.5.0"
 
 
 [features]

--- a/rrule-debugger/src/debug.rs
+++ b/rrule-debugger/src/debug.rs
@@ -2,7 +2,7 @@
 #![allow(unused_imports)]
 use chrono::{DateTime, TimeZone, Weekday};
 use chrono_tz::{Tz, UTC};
-use rrule::{Frequency, RRule, RRuleProperties};
+use rrule::{DateFilter, Frequency, RRule, RRuleProperties};
 
 /// This function can be used to test anything and can be changes as you wish.
 pub fn run_debug_function() {

--- a/rrule-debugger/src/iter_rrule.rs
+++ b/rrule-debugger/src/iter_rrule.rs
@@ -1,3 +1,5 @@
+use rrule::DateFilter;
+
 pub fn from_crash_file(id: u32, data: &[u8]) {
     println!("--------- Test file {} -----------", id);
 

--- a/rrule-debugger/src/parser_rrule.rs
+++ b/rrule-debugger/src/parser_rrule.rs
@@ -1,4 +1,4 @@
-use rrule::RRule;
+use rrule::{DateFilter, RRule};
 use std::str::FromStr;
 
 pub fn from_crash_file(id: u32, data: &[u8]) {

--- a/rrule-debugger/src/simple_logger.rs
+++ b/rrule-debugger/src/simple_logger.rs
@@ -1,0 +1,47 @@
+use log::{Level, Metadata, Record};
+pub use yansi::Paint;
+
+/// An instance of the `Logger`.
+pub static LOGGER: Logger = Logger;
+/// The log collector and handler for most printed messages in terminal.
+pub struct Logger;
+
+impl log::Log for Logger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        let enable = if !cfg!(debug_assertions) {
+            // Only in release mode
+            // Do the filters below unless it is a Warning, Error (or Debug)
+            metadata.level() == Level::Warn
+                || metadata.level() == Level::Error
+                || metadata.level() == Level::Debug
+        } else {
+            // Don't apply additional filters in debug build
+            true
+        };
+
+        // All messages need to be Trace or lower
+        metadata.level() <= Level::Trace
+            // If release mode filter on
+            && enable
+    }
+
+    fn log(&self, record: &Record) {
+        if self.enabled(record.metadata()) {
+            // Print to stderr instead of stdout
+            eprintln!(
+                "{:<5}:{} - {}",
+                match record.level() {
+                    Level::Error => Paint::red("ERROR"),
+                    Level::Warn => Paint::yellow("WARN"),
+                    Level::Info => Paint::blue("INFO"),
+                    Level::Debug => Paint::green("DEBUG"),
+                    Level::Trace => Paint::magenta("TRACE"),
+                },
+                Paint::new(record.target()).dimmed(),
+                record.args()
+            );
+        }
+    }
+
+    fn flush(&self) {}
+}

--- a/rrule/examples/manual_properties.rs
+++ b/rrule/examples/manual_properties.rs
@@ -4,7 +4,7 @@
 
 use chrono::{Datelike, TimeZone, Timelike};
 use chrono_tz::UTC;
-use rrule::{Frequency, RRule, RRuleProperties};
+use rrule::{DateFilter, Frequency, RRule, RRuleProperties};
 
 fn main() {
     // Build properties that starts first day in 2020 at 9:00AM and occurs daily 5 times
@@ -15,8 +15,8 @@ fn main() {
 
     // Construct `RRule` from properties
     let rrule = RRule::new(properties).expect("RRule invalid");
-    let recurrences = rrule.all(100);
-    for (i, rec) in rrule.all(100).iter().enumerate().take(5) {
+    let recurrences = rrule.all(100).unwrap();
+    for (i, rec) in rrule.all(100).unwrap().iter().enumerate().take(5) {
         assert_eq!(rec.year(), 2020);
         assert_eq!(rec.month(), 1);
         assert_eq!(rec.day(), 1 + i as u32);

--- a/rrule/examples/manual_properties.rs
+++ b/rrule/examples/manual_properties.rs
@@ -14,9 +14,9 @@ fn main() {
         .freq(Frequency::Daily);
 
     // Construct `RRule` from properties
-    let rrule = RRule::new(properties).expect("RRule invalid");
-    let recurrences = rrule.all(100).unwrap();
-    for (i, rec) in rrule.all(100).unwrap().iter().enumerate().take(5) {
+    let rrule = RRule::new(properties).expect("RRule invalid.");
+    let recurrences = rrule.all(10).expect("Error found during iterations.");
+    for (i, rec) in recurrences.iter().enumerate() {
         assert_eq!(rec.year(), 2020);
         assert_eq!(rec.month(), 1);
         assert_eq!(rec.day(), 1 + i as u32);

--- a/rrule/examples/manual_rrule_set.rs
+++ b/rrule/examples/manual_rrule_set.rs
@@ -4,7 +4,7 @@
 
 use chrono::{Datelike, TimeZone};
 use chrono_tz::UTC;
-use rrule::{Frequency, NWeekday, RRule, RRuleProperties, RRuleSet, Weekday};
+use rrule::{DateFilter, Frequency, NWeekday, RRule, RRuleProperties, RRuleSet, Weekday};
 
 /// ## Construct `RRuleSet` from one `rrule` and `exrule`
 /// The rrule will occur weekly on Tuesday and Wednesday and the exrule
@@ -39,7 +39,7 @@ fn main() {
     rrule_set.rrule(rrule);
     rrule_set.exrule(exrule);
 
-    let recurrences = rrule_set.all(100);
+    let recurrences = rrule_set.all(100).unwrap();
 
     // Check that all the recurrences are on a Tuesday
     for occurrence in &recurrences {

--- a/rrule/examples/timezone_support.rs
+++ b/rrule/examples/timezone_support.rs
@@ -6,7 +6,7 @@
 
 use chrono::{DateTime, Local, TimeZone};
 use chrono_tz::{Europe::Berlin, Tz, UTC};
-use rrule::{Frequency, RRule, RRuleProperties, RRuleSet};
+use rrule::{DateFilter, Frequency, RRule, RRuleProperties, RRuleSet};
 
 fn main() {
     // Build properties for rrule that occurs daily at 9:00 for 4 times
@@ -26,7 +26,7 @@ fn main() {
     rrule_set.rrule(rrule);
     rrule_set.exdate(exdate);
 
-    let recurrences = rrule_set.all(100);
+    let recurrences = rrule_set.all(100).unwrap();
     // RRule contained 4 recurrences but 1 was filtered away by the exdate
     assert_eq!(recurrences.len(), 3);
 

--- a/rrule/src/core/date_filter.rs
+++ b/rrule/src/core/date_filter.rs
@@ -1,14 +1,10 @@
 use super::datetime::DateTime;
 use crate::{RRuleError, WithError};
-use std::iter::FromIterator;
 
 pub trait DateFilter<'a, T>
 where
-    Self: Sized,
-    &'a Self: 'a + IntoIterator + Sized + IntoIterator<IntoIter = T>,
+    &'a Self: 'a + Sized + IntoIterator<IntoIter = T>,
     T: Iterator<Item = DateTime> + WithError,
-    // T: Iterator<Item = DateTime> + WithError,
-    Vec<DateTime>: FromIterator<<T as Iterator>::Item>,
 {
     /// Returns all the recurrences of the rrule.
     ///

--- a/rrule/src/core/date_filter.rs
+++ b/rrule/src/core/date_filter.rs
@@ -19,7 +19,7 @@ where
     /// Limit must be set in order to prevent infinite loops.
     /// The max limit is `65535`. If you need more please use `into_iter` directly.
     ///
-    /// In case where the iterator ended with an errors the error will be included,
+    /// In case the iterator ended with an error, the error will be included,
     /// otherwise the second value of the return tuple will be `None`.
     fn all_with_error(&'a self, limit: u16) -> (Vec<DateTime>, Option<RRuleError>) {
         super::collect_with_error(self.into_iter(), &None, &None, true, limit)
@@ -46,7 +46,7 @@ where
     /// Limit must be set in order to prevent infinite loops.
     /// The max limit is `65535`. If you need more please use `into_iter` directly.
     ///
-    /// In case where the iterator ended with an errors the error will be included,
+    /// In case the iterator ended with an error, the error will be included,
     /// otherwise the second value of the return tuple will be `None`.
     fn all_before_with_error(
         &'a self,
@@ -78,7 +78,7 @@ where
     /// Limit must be set in order to prevent infinite loops.
     /// The max limit is `65535`. If you need more please use `into_iter` directly.
     ///
-    /// In case where the iterator ended with an errors the error will be included,
+    /// In case the iterator ended with an error, the error will be included,
     /// otherwise the second value of the return tuple will be `None`.
     fn all_after_with_error(
         &'a self,
@@ -114,7 +114,7 @@ where
     /// Limit must be set in order to prevent infinite loops.
     /// The max limit is `65535`. If you need more please use `into_iter` directly.
     ///
-    /// In case where the iterator ended with an errors the error will be included,
+    /// In case the iterator ended with an error, the error will be included,
     /// otherwise the second value of the return tuple will be `None`.
     fn all_between_with_error(
         &'a self,

--- a/rrule/src/core/date_filter.rs
+++ b/rrule/src/core/date_filter.rs
@@ -1,0 +1,132 @@
+use super::datetime::DateTime;
+use crate::{RRuleError, WithError};
+use std::iter::FromIterator;
+
+pub trait DateFilter<'a, T>
+where
+    Self: Sized,
+    &'a Self: 'a + IntoIterator + Sized + IntoIterator<IntoIter = T>,
+    T: Iterator<Item = DateTime> + WithError,
+    // T: Iterator<Item = DateTime> + WithError,
+    Vec<DateTime>: FromIterator<<T as Iterator>::Item>,
+{
+    /// Returns all the recurrences of the rrule.
+    ///
+    /// Limit must be set in order to prevent infinite loops.
+    /// The max limit is `65535`. If you need more please use `into_iter` directly.
+    fn all(&'a self, limit: u16) -> Result<Vec<DateTime>, RRuleError> {
+        super::collect_or_error(self.into_iter(), &None, &None, true, limit)
+    }
+
+    /// Returns all the recurrences of the rrule.
+    ///
+    /// Limit must be set in order to prevent infinite loops.
+    /// The max limit is `65535`. If you need more please use `into_iter` directly.
+    ///
+    /// In case where the iterator ended with an errors the error will be included,
+    /// otherwise the second value of the return tuple will be `None`.
+    fn all_with_error(&'a self, limit: u16) -> (Vec<DateTime>, Option<RRuleError>) {
+        super::collect_with_error(self.into_iter(), &None, &None, true, limit)
+    }
+
+    /// Returns the last recurrence before the given datetime instance.
+    ///
+    /// The `inclusive` keyword defines what happens if `before` is a recurrence.
+    /// With `inclusive == true`, if `before` itself is a recurrence, it will be returned.
+    fn just_before(
+        &'a self,
+        before: DateTime,
+        inclusive: bool,
+    ) -> Result<Option<DateTime>, RRuleError> {
+        Ok(
+            super::collect_or_error(self.into_iter(), &None, &Some(before), inclusive, u16::MAX)?
+                .last()
+                .cloned(),
+        )
+    }
+
+    /// Returns all the recurrences of the rrule before the given date.
+    ///
+    /// Limit must be set in order to prevent infinite loops.
+    /// The max limit is `65535`. If you need more please use `into_iter` directly.
+    ///
+    /// In case where the iterator ended with an errors the error will be included,
+    /// otherwise the second value of the return tuple will be `None`.
+    fn all_before_with_error(
+        &'a self,
+        before: DateTime,
+        inclusive: bool,
+        limit: u16,
+    ) -> (Vec<DateTime>, Option<RRuleError>) {
+        super::collect_with_error(self.into_iter(), &None, &Some(before), inclusive, limit)
+    }
+
+    /// Returns the last recurrence after the given datetime instance.
+    ///
+    /// The `inclusive` keyword defines what happens if `after` is a recurrence.
+    /// With `inclusive == true`, if `after` itself is a recurrence, it will be returned.
+    fn just_after(
+        &'a self,
+        after: DateTime,
+        inclusive: bool,
+    ) -> Result<Option<DateTime>, RRuleError> {
+        Ok(
+            super::collect_or_error(self.into_iter(), &Some(after), &None, inclusive, 1)?
+                .first()
+                .cloned(),
+        )
+    }
+
+    /// Returns all the recurrences of the rrule after the given date.
+    ///
+    /// Limit must be set in order to prevent infinite loops.
+    /// The max limit is `65535`. If you need more please use `into_iter` directly.
+    ///
+    /// In case where the iterator ended with an errors the error will be included,
+    /// otherwise the second value of the return tuple will be `None`.
+    fn all_after_with_error(
+        &'a self,
+        after: DateTime,
+        inclusive: bool,
+        limit: u16,
+    ) -> (Vec<DateTime>, Option<RRuleError>) {
+        super::collect_with_error(self.into_iter(), &Some(after), &None, inclusive, limit)
+    }
+
+    /// Returns all the recurrences of the rrule between after and before.
+    ///
+    /// The `inclusive` keyword defines what happens if after and/or before are
+    /// themselves recurrences. With `inclusive == true`, they will be included in the
+    /// list, if they are found in the recurrence set.
+    fn all_between(
+        &'a self,
+        start: DateTime,
+        end: DateTime,
+        inclusive: bool,
+    ) -> Result<Vec<DateTime>, RRuleError> {
+        super::collect_or_error(
+            self.into_iter(),
+            &Some(start),
+            &Some(end),
+            inclusive,
+            u16::MAX,
+        )
+    }
+
+    /// Returns all the recurrences of the rrule after the given date and before the other date.
+    ///
+    /// Limit must be set in order to prevent infinite loops.
+    /// The max limit is `65535`. If you need more please use `into_iter` directly.
+    ///
+    /// In case where the iterator ended with an errors the error will be included,
+    /// otherwise the second value of the return tuple will be `None`.
+    fn all_between_with_error(
+        &'a self,
+        start: DateTime,
+        end: DateTime,
+        inclusive: bool,
+        limit: u16,
+    ) -> (Vec<DateTime>, Option<RRuleError>) {
+        super::collect_with_error(self.into_iter(), &Some(start), &Some(end), inclusive, limit)
+    }
+}

--- a/rrule/src/core/mod.rs
+++ b/rrule/src/core/mod.rs
@@ -1,9 +1,13 @@
+mod date_filter;
 mod datetime;
 mod properties;
 mod rrule;
 mod rruleset;
+mod utils;
 
 pub use self::rrule::RRule;
+pub use date_filter::DateFilter;
 pub(crate) use datetime::{DateTime, Time};
 pub use properties::{Frequency, NWeekday, RRuleProperties};
 pub use rruleset::RRuleSet;
+pub(self) use utils::{collect_or_error, collect_with_error};

--- a/rrule/src/core/rrule.rs
+++ b/rrule/src/core/rrule.rs
@@ -1,5 +1,5 @@
-use super::{datetime::DateTime, properties::*};
-use crate::{validator::validate_properties, RRuleError, WithError};
+use super::properties::*;
+use crate::{validator::validate_properties, DateFilter, RRuleError, RRuleIter};
 use std::str::FromStr;
 
 /// A validated Recurrence Rule that can be used to create an iterator.
@@ -26,64 +26,6 @@ impl RRule {
     pub fn get_properties(&self) -> &RRuleProperties {
         &self.properties
     }
-
-    /// Returns all the recurrences of the rrule.
-    /// Limit must be set in order to prevent infinite loops.
-    /// The max limit is `65535`. If you need more please use `into_iter` directly.
-    pub fn all(&self, limit: u16) -> Vec<DateTime> {
-        self.into_iter().take(limit as usize).collect()
-    }
-
-    /// Returns all the recurrences of the rrule.
-    /// Limit must be set in order to prevent infinite loops.
-    /// The max limit is `65535`. If you need more please use `into_iter` directly.
-    ///
-    /// In case where the iterator ended with an errors the error will be included,
-    /// otherwise the second value of the return tuple will be `None`.
-    pub fn all_with_error(&self, limit: u16) -> (Vec<DateTime>, Option<RRuleError>) {
-        let mut iterator = self.into_iter();
-        let mut list = vec![];
-        let mut err = None;
-        for _i in 0..limit {
-            let next = iterator.next();
-            match next {
-                Some(value) => list.push(value),
-                None => {
-                    err = iterator.get_err();
-                    break;
-                }
-            }
-        }
-        (list, err.cloned())
-    }
-
-    /// Returns the last recurrence before the given datetime instance.
-    /// The inc keyword defines what happens if dt is a recurrence.
-    /// With inc == true, if dt itself is a recurrence, it will be returned.
-    pub fn before(&self, dt: DateTime, inc: bool) -> Option<DateTime> {
-        self.into_iter()
-            .take_while(|d| if inc { *d <= dt } else { *d < dt })
-            .last()
-    }
-
-    /// Returns the last recurrence after the given datetime instance.
-    /// The inc keyword defines what happens if dt is a recurrence.
-    /// With inc == true, if dt itself is a recurrence, it will be returned.
-    pub fn after(&self, dt: DateTime, inc: bool) -> Option<DateTime> {
-        self.into_iter()
-            .find(|d| !(if inc { *d < dt } else { *d <= dt }))
-    }
-
-    /// Returns all the recurrences of the rrule between after and before.
-    /// The inc keyword defines what happens if after and/or before are
-    /// themselves recurrences. With inc == true, they will be included in the
-    /// list, if they are found in the recurrence set.
-    pub fn between(&self, after: DateTime, before: DateTime, inc: bool) -> Vec<DateTime> {
-        self.into_iter()
-            .skip_while(|d| if inc { *d < after } else { *d <= after })
-            .take_while(|d| if inc { *d <= before } else { *d < before })
-            .collect()
-    }
 }
 
 impl FromStr for RRule {
@@ -94,3 +36,5 @@ impl FromStr for RRule {
         RRule::new(properties)
     }
 }
+
+impl<'a> DateFilter<'a, RRuleIter<'a>> for RRule {}

--- a/rrule/src/core/rruleset.rs
+++ b/rrule/src/core/rruleset.rs
@@ -1,5 +1,5 @@
 use super::{datetime::DateTime, rrule::RRule};
-use crate::{parser::build_rruleset, RRuleError, WithError};
+use crate::{parser::build_rruleset, DateFilter, RRuleError, RRuleSetIter};
 use chrono::TimeZone;
 use chrono_tz::UTC;
 use std::str::FromStr;
@@ -41,66 +41,6 @@ impl RRuleSet {
     pub fn exdate(&mut self, exdate: DateTime) {
         self.exdate.push(exdate);
     }
-
-    /// Returns all the recurrences of the rruleset.
-    /// Limit must be set in order to prevent infinite loops.
-    /// The max limit is `65535`. If you need more please use `into_iter` directly.
-    pub fn all(&self, limit: u16) -> Vec<DateTime> {
-        self.into_iter().take(limit as usize).collect()
-    }
-
-    /// Returns all the recurrences of the rrule.
-    /// Limit must be set in order to prevent infinite loops.
-    /// The max limit is `65535`. If you need more please use `into_iter` directly.
-    ///
-    /// In case where the iterator ended with an errors the error will be included,
-    /// otherwise the second value of the return tuple will be `None`.
-    pub fn all_with_error(&self, limit: u16) -> (Vec<DateTime>, Option<RRuleError>) {
-        let mut iterator = self.into_iter();
-        let mut list = vec![];
-        let mut err = None;
-        for _i in 0..limit {
-            let next = iterator.next();
-            match next {
-                Some(value) => list.push(value),
-                None => {
-                    if iterator.has_err() {
-                        err = iterator.get_err();
-                    }
-                    break;
-                }
-            }
-        }
-        (list, err.cloned())
-    }
-
-    /// Returns the last recurrence before the given datetime instance.
-    /// The inc keyword defines what happens if dt is a recurrence.
-    /// With inc == true, if dt itself is a recurrence, it will be returned.
-    pub fn before(&self, dt: DateTime, inc: bool) -> Option<DateTime> {
-        self.into_iter()
-            .take_while(|d| if inc { *d <= dt } else { *d < dt })
-            .last()
-    }
-
-    /// Returns the last recurrence after the given datetime instance.
-    /// The inc keyword defines what happens if dt is a recurrence.
-    /// With inc == true, if dt itself is a recurrence, it will be returned.
-    pub fn after(&self, dt: DateTime, inc: bool) -> Option<DateTime> {
-        self.into_iter()
-            .find(|d| !(if inc { *d <= dt } else { *d < dt }))
-    }
-
-    /// Returns all the recurrences of the rrule between after and before.
-    /// The inc keyword defines what happens if after and/or before are
-    /// themselves recurrences. With inc == true, they will be included in the
-    /// list, if they are found in the recurrence set.
-    pub fn between(&self, after: DateTime, before: DateTime, inc: bool) -> Vec<DateTime> {
-        self.into_iter()
-            .skip_while(|d| if inc { *d <= after } else { *d < after })
-            .take_while(|d| if inc { *d <= before } else { *d < before })
-            .collect()
-    }
 }
 
 impl FromStr for RRuleSet {
@@ -110,3 +50,5 @@ impl FromStr for RRuleSet {
         build_rruleset(s)
     }
 }
+
+impl<'a> DateFilter<'a, RRuleSetIter<'a>> for RRuleSet {}

--- a/rrule/src/core/utils.rs
+++ b/rrule/src/core/utils.rs
@@ -1,0 +1,369 @@
+use super::DateTime;
+use crate::{RRuleError, WithError};
+
+/// Collect all dates, but once an error is found it will return the error
+/// and not the items that where already found.
+pub(crate) fn collect_or_error<T>(
+    iterator: T,
+    start: &Option<DateTime>,
+    end: &Option<DateTime>,
+    inclusive: bool,
+    limit: u16,
+) -> Result<Vec<DateTime>, RRuleError>
+where
+    T: Iterator<Item = DateTime> + WithError,
+{
+    match collect_with_error(iterator, start, end, inclusive, limit) {
+        (_list, Some(err)) => Err(err),
+        (list, None) => Ok(list),
+    }
+}
+
+/// Helper function to collect dates given some filters.
+///
+/// In case where the iterator ended with an errors the error will be included,
+/// otherwise the second value of the return tuple will be `None`.
+pub(crate) fn collect_with_error<T>(
+    mut iterator: T,
+    start: &Option<DateTime>,
+    end: &Option<DateTime>,
+    inclusive: bool,
+    limit: u16,
+) -> (Vec<DateTime>, Option<RRuleError>)
+where
+    T: Iterator<Item = DateTime> + WithError,
+{
+    let mut list = vec![];
+    let mut err = None;
+    // This loop should always end because `.next()` has build in limits
+    // Once a limit is tripped it will break in the `None` case.
+    while list.len() < limit as usize {
+        let next = iterator.next();
+        match next {
+            Some(value) => {
+                if is_in_range(&value, start, end, inclusive) {
+                    list.push(value);
+                }
+                if reached_end(&value, end, inclusive) {
+                    // Date is after end date, so can stop iterating
+                    break;
+                }
+            }
+            None => {
+                if iterator.has_err() {
+                    err = iterator.get_err();
+                }
+                break;
+            }
+        }
+    }
+    // Make sure that the user always know when there are more dates.
+    if list.len() >= u16::MAX as usize {
+        (
+            list,
+            Some(RRuleError::new_iter_err(format!(
+                "List reached maximum limit (`{}`), so there might be more items.",
+                u16::MAX
+            ))),
+        )
+    } else {
+        (list, err.cloned())
+    }
+}
+
+/// Check if `date` is after `end`.
+fn reached_end(date: &DateTime, end: &Option<DateTime>, inclusive: bool) -> bool {
+    use std::ops::{
+        Bound::{Excluded, Unbounded},
+        RangeBounds,
+    };
+    if inclusive {
+        match end {
+            Some(end) => !(..=end).contains(&date),
+            None => false,
+        }
+    } else {
+        match end {
+            Some(end) => !(Unbounded, Excluded(end)).contains(date),
+            None => false,
+        }
+    }
+}
+
+/// Helper function to determine if a date is within a given range.
+pub(crate) fn is_in_range(
+    date: &DateTime,
+    start: &Option<DateTime>,
+    end: &Option<DateTime>,
+    inclusive: bool,
+) -> bool {
+    use std::ops::{
+        Bound::{Excluded, Unbounded},
+        RangeBounds,
+    };
+    // Should it include or not include the start and/or end date?
+    if inclusive {
+        match (start, end) {
+            (Some(start), Some(end)) => (start..=end).contains(&date),
+            (Some(start), None) => (start..).contains(&date),
+            (None, Some(end)) => (..=end).contains(&date),
+            (None, None) => true,
+        }
+    } else {
+        match (start, end) {
+            (Some(start), Some(end)) => (Excluded(start), Excluded(end)).contains(date),
+            (Some(start), None) => (Excluded(start), Unbounded).contains(date),
+            (None, Some(end)) => (Unbounded, Excluded(end)).contains(date),
+            (None, None) => true,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use chrono_tz::UTC;
+
+    #[test]
+    fn in_range_exclusive_start_to_end() {
+        let inclusive = false;
+        let start = UTC.ymd(2021, 10, 1).and_hms(8, 0, 0);
+        let end = UTC.ymd(2021, 10, 1).and_hms(10, 0, 0);
+
+        // In middle
+        assert!(is_in_range(
+            &UTC.ymd(2021, 10, 1).and_hms(9, 0, 0),
+            &Some(start),
+            &Some(end),
+            inclusive
+        ));
+        // To small
+        assert!(!is_in_range(
+            &UTC.ymd(2021, 10, 1).and_hms(7, 0, 0),
+            &Some(start),
+            &Some(end),
+            inclusive
+        ));
+        // To big
+        assert!(!is_in_range(
+            &UTC.ymd(2021, 10, 1).and_hms(11, 0, 0),
+            &Some(start),
+            &Some(end),
+            inclusive
+        ));
+        // Equal to end
+        assert!(!is_in_range(&end, &Some(start), &Some(end), inclusive));
+        // Equal to start
+        assert!(!is_in_range(&start, &Some(start), &Some(end), inclusive));
+    }
+
+    #[test]
+    fn in_range_exclusive_start() {
+        let inclusive = false;
+        let start = UTC.ymd(2021, 10, 1).and_hms(8, 0, 0);
+
+        // Just after
+        assert!(is_in_range(
+            &UTC.ymd(2021, 10, 1).and_hms(9, 0, 0),
+            &Some(start),
+            &None,
+            inclusive
+        ));
+        // To small
+        assert!(!is_in_range(
+            &UTC.ymd(2021, 10, 1).and_hms(7, 0, 0),
+            &Some(start),
+            &None,
+            inclusive
+        ));
+        // Bigger
+        assert!(is_in_range(
+            &UTC.ymd(2021, 10, 2).and_hms(8, 0, 0),
+            &Some(start),
+            &None,
+            inclusive
+        ));
+        // Equal to start
+        assert!(!is_in_range(&start, &Some(start), &None, inclusive));
+    }
+
+    #[test]
+    fn in_range_exclusive_end() {
+        let inclusive = false;
+        let end = UTC.ymd(2021, 10, 1).and_hms(10, 0, 0);
+
+        // Just before
+        assert!(is_in_range(
+            &UTC.ymd(2021, 10, 1).and_hms(9, 0, 0),
+            &None,
+            &Some(end),
+            inclusive
+        ));
+        // Smaller
+        assert!(is_in_range(
+            &UTC.ymd(2021, 9, 20).and_hms(10, 0, 0),
+            &None,
+            &Some(end),
+            inclusive
+        ));
+        // Bigger
+        assert!(!is_in_range(
+            &UTC.ymd(2021, 10, 2).and_hms(8, 0, 0),
+            &None,
+            &Some(end),
+            inclusive
+        ));
+        // Equal to end
+        assert!(!is_in_range(&end, &None, &Some(end), inclusive));
+    }
+
+    #[test]
+    fn in_range_exclusive_all() {
+        let inclusive = false;
+
+        // Some date
+        assert!(is_in_range(
+            &UTC.ymd(2021, 10, 1).and_hms(9, 0, 0),
+            &None,
+            &None,
+            inclusive
+        ));
+        // Smaller
+        assert!(is_in_range(
+            &UTC.ymd(2021, 9, 20).and_hms(10, 0, 0),
+            &None,
+            &None,
+            inclusive
+        ));
+        // Bigger
+        assert!(is_in_range(
+            &UTC.ymd(2021, 10, 2).and_hms(8, 0, 0),
+            &None,
+            &None,
+            inclusive
+        ));
+    }
+
+    // ---------------- inclusive -----------------------
+
+    #[test]
+    fn in_range_inclusive_start_to_end() {
+        let inclusive = true;
+        let start = UTC.ymd(2021, 10, 1).and_hms(8, 0, 0);
+        let end = UTC.ymd(2021, 10, 1).and_hms(10, 0, 0);
+
+        // In middle
+        assert!(is_in_range(
+            &UTC.ymd(2021, 10, 1).and_hms(9, 0, 0),
+            &Some(start),
+            &Some(end),
+            inclusive
+        ));
+        // To small
+        assert!(!is_in_range(
+            &UTC.ymd(2021, 10, 1).and_hms(7, 0, 0),
+            &Some(start),
+            &Some(end),
+            inclusive
+        ));
+        // To big
+        assert!(!is_in_range(
+            &UTC.ymd(2021, 10, 1).and_hms(11, 0, 0),
+            &Some(start),
+            &Some(end),
+            inclusive
+        ));
+        // Equal to end
+        assert!(is_in_range(&end, &Some(start), &Some(end), inclusive));
+        // Equal to start
+        assert!(is_in_range(&start, &Some(start), &Some(end), inclusive));
+    }
+
+    #[test]
+    fn in_range_inclusive_start() {
+        let inclusive = true;
+        let start = UTC.ymd(2021, 10, 1).and_hms(8, 0, 0);
+
+        // Just after
+        assert!(is_in_range(
+            &UTC.ymd(2021, 10, 1).and_hms(9, 0, 0),
+            &Some(start),
+            &None,
+            inclusive
+        ));
+        // To small
+        assert!(!is_in_range(
+            &UTC.ymd(2021, 10, 1).and_hms(7, 0, 0),
+            &Some(start),
+            &None,
+            inclusive
+        ));
+        // Bigger
+        assert!(is_in_range(
+            &UTC.ymd(2021, 10, 2).and_hms(8, 0, 0),
+            &Some(start),
+            &None,
+            inclusive
+        ));
+        // Equal to start
+        assert!(is_in_range(&start, &Some(start), &None, inclusive));
+    }
+
+    #[test]
+    fn in_range_inclusive_end() {
+        let inclusive = true;
+        let end = UTC.ymd(2021, 10, 1).and_hms(10, 0, 0);
+
+        // Just before
+        assert!(is_in_range(
+            &UTC.ymd(2021, 10, 1).and_hms(9, 0, 0),
+            &None,
+            &Some(end),
+            inclusive
+        ));
+        // Smaller
+        assert!(is_in_range(
+            &UTC.ymd(2021, 9, 20).and_hms(10, 0, 0),
+            &None,
+            &Some(end),
+            inclusive
+        ));
+        // Bigger
+        assert!(!is_in_range(
+            &UTC.ymd(2021, 10, 2).and_hms(8, 0, 0),
+            &None,
+            &Some(end),
+            inclusive
+        ));
+        // Equal to end
+        assert!(is_in_range(&end, &None, &Some(end), inclusive));
+    }
+
+    #[test]
+    fn in_range_inclusive_all() {
+        let inclusive = true;
+
+        // Some date
+        assert!(is_in_range(
+            &UTC.ymd(2021, 10, 1).and_hms(9, 0, 0),
+            &None,
+            &None,
+            inclusive
+        ));
+        // Smaller
+        assert!(is_in_range(
+            &UTC.ymd(2021, 9, 20).and_hms(10, 0, 0),
+            &None,
+            &None,
+            inclusive
+        ));
+        // Bigger
+        assert!(is_in_range(
+            &UTC.ymd(2021, 10, 2).and_hms(8, 0, 0),
+            &None,
+            &None,
+            inclusive
+        ));
+    }
+}

--- a/rrule/src/iter/rruleset_iter.rs
+++ b/rrule/src/iter/rruleset_iter.rs
@@ -1,5 +1,5 @@
 use super::{rrule_iter::RRuleIter, MAX_ITER_LOOP};
-use crate::{core::DateTime, RRule, RRuleError, RRuleSet, WithError};
+use crate::{core::DateTime, DateFilter, RRule, RRuleError, RRuleSet, WithError};
 use chrono::TimeZone;
 use std::{collections::HashMap, iter::Iterator};
 
@@ -70,6 +70,7 @@ impl<'a> RRuleSetIter<'a> {
         Ok(date)
     }
 
+    // TODO should this be called `accept` or `except`?
     fn accept_generated_date(
         date: &Option<DateTime>,
         exrules: &[RRule],
@@ -84,7 +85,7 @@ impl<'a> RRuleSetIter<'a> {
                     let after = date.timezone().timestamp(dt - 1, 0);
                     let before = date.timezone().timestamp(dt + 1, 0);
                     for exrule in exrules {
-                        for date in exrule.between(after, before, true) {
+                        for date in exrule.all_between(after, before, true).unwrap() {
                             exdates.insert(date.timestamp(), ());
                         }
                     }

--- a/rrule/src/iter/yearinfo.rs
+++ b/rrule/src/iter/yearinfo.rs
@@ -16,6 +16,8 @@ pub(crate) struct YearInfo {
     /// Get day of the week from first day of the year (1 jan)
     /// So if `YYYY/01/01` is a wednesday this value will be `2`.
     /// Can be any value from 0..=6 (monday = 0)
+    // TODO: Why is this field never used?
+    #[allow(dead_code)]
     pub year_weekday: u8,
     pub month_mask: &'static [u8],
     pub month_day_mask: &'static [i8],

--- a/rrule/src/lib.rs
+++ b/rrule/src/lib.rs
@@ -13,58 +13,52 @@
 //! exdate and rdate properties. See the examples below.
 //!
 //! # Generating occurrences
-//! `RRule` and `RRuleSet` have four quick start methods for "querying" for recurrences:
+//! `RRule` and `RRuleSet` both implement `DateFilter` which implements methods for easy filtering:
 //! - `all`: Generate all recurrences that matches the rules (with a limit to prevent infinite loops).
-//! - `between`: Generate all recurrences that matches the rules and are between two given dates.
-//! - `before`: Generate the last recurrence that matches the rules and is before a given date.
-//! - `after`: Generate the first recurrence that matches the rules and is after a given date.
+//! - `all_between`: Generate all recurrences that matches the rules and are between two given dates.
+//! - `just_before`: Generate the last recurrence that matches the rules and is before a given date.
+//! - `just_after`: Generate the first recurrence that matches the rules and is after a given date.
+//! - ...
 //!
 //! If you have some additional filters or want to work with infinite recurrence rules
 //! both `RRule` and `RRuleSet` implements the `Iterator` traits which makes them very flexible.
 //! All the methods above uses the iterator trait in its implementation as shown below.
 //! ```rust
-//! use chrono::TimeZone;
+//! use chrono::{DateTime, TimeZone};
 //! use chrono_tz::UTC;
-//! use rrule::RRule;
+//! use rrule::{DateFilter, RRule};
 //!
 //! let rrule: RRule = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=3".parse().unwrap();
 //!
 //! // All dates
-//! let all_occurrences: Vec<_> = rrule.clone().into_iter().collect();
-//! assert_eq!(all_occurrences, rrule.all(100));
-//!
+//! assert_eq!(
+//!     vec![
+//!         DateTime::parse_from_rfc3339("2012-02-01T09:30:00+00:00").unwrap(),
+//!         DateTime::parse_from_rfc3339("2012-02-02T09:30:00+00:00").unwrap(),
+//!         DateTime::parse_from_rfc3339("2012-02-03T09:30:00+00:00").unwrap(),
+//!     ],
+//!     rrule.all(100).unwrap()
+//! );
+//! ```
+//! Find all events that are within a given range.
+//! ```rust
+//! # use chrono::{DateTime, TimeZone};
+//! # use chrono_tz::UTC;
+//! # use rrule::{DateFilter, RRule};
+//! #
+//! let rrule: RRule = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=3".parse().unwrap();
 //! // Between two dates
 //! let after = UTC.ymd(2012, 2, 1).and_hms(10, 0, 0);
 //! let before = UTC.ymd(2012, 4, 1).and_hms(9, 0, 0);
 //! let inc = true; // Whether dates equal to after or before should be added;
 //!
-//! let occurrences_between_dates: Vec<_> = rrule.clone()
-//!     .into_iter()
-//!     .skip_while(|d| if inc { *d <= after } else { *d < after })
-//!     .take_while(|d| if inc { *d <= before } else { *d < before })
-//!     .collect();
-//! assert_eq!(occurrences_between_dates, rrule.between(after, before, inc));
-//!
-//! // After a date
-//! let after = UTC.ymd(2012, 2, 1).and_hms(10, 0, 0);
-//! let inc = true; // Whether dates equals to after should be added;
-//!
-//! let occurrence_after_date = rrule.clone()
-//!     .into_iter()
-//!     .skip_while(|d| if inc { *d <= after } else { *d < after })
-//!     .next();
-//! assert_eq!(occurrence_after_date, rrule.after(after, inc));
-//!
-//! // Before a date
-//! let before = UTC.ymd(2012, 4, 1).and_hms(10, 0, 0);
-//! let inc = true; // Whether dates equals to before should be added;
-//!
-//! let occurrence_before_date = rrule.clone()
-//!     .into_iter()
-//!     .take_while(|d| if inc { *d <= before } else { *d < before })
-//!     .last();
-//! assert_eq!(occurrence_before_date, rrule.before(before, inc));
-//!
+//! assert_eq!(
+//!     vec![
+//!         DateTime::parse_from_rfc3339("2012-02-02T09:30:00+00:00").unwrap(),
+//!         DateTime::parse_from_rfc3339("2012-02-03T09:30:00+00:00").unwrap(),
+//!     ],
+//!     rrule.all_between(after, before, inc).unwrap()
+//! );
 //! ```
 //!
 //! Note: All the generated recurrence will be in the same time zone as the `dt_start` property.
@@ -74,12 +68,13 @@
 //! Quick start by parsing strings
 //!
 //! ```rust
-//! use rrule::RRule;
+//! use chrono::DateTime;
+//! use rrule::{DateFilter, RRule};
 //!
 //! // Parse a RRule string
 //! let rrule: RRule = "DTSTART:20120201T093000Z\n\
 //!    RRULE:FREQ=WEEKLY;INTERVAL=5;UNTIL=20130130T230000Z;BYDAY=MO,FR".parse().unwrap();
-//! assert_eq!(rrule.all(100).len(), 21);
+//! assert_eq!(rrule.all(100).unwrap().len(), 21);
 //!
 //! use rrule::RRuleSet;
 //!
@@ -89,7 +84,18 @@
 //!     RDATE:20120701T023000Z,20120702T023000Z\n\
 //!     EXRULE:FREQ=MONTHLY;COUNT=2\n\
 //!     EXDATE:20120601T023000Z".parse().unwrap();
-//! assert_eq!(rrule_set.all(100).len(), 4);
+//! let all_dates = rrule_set.all(100).unwrap();
+//! assert_eq!(all_dates.len(), 4);
+//!
+//! assert_eq!(
+//!     vec![
+//!         DateTime::parse_from_rfc3339("2012-04-01T02:30:00+00:00").unwrap(),
+//!         DateTime::parse_from_rfc3339("2012-05-01T02:30:00+00:00").unwrap(),
+//!         DateTime::parse_from_rfc3339("2012-07-01T02:30:00+00:00").unwrap(),
+//!         DateTime::parse_from_rfc3339("2012-07-02T02:30:00+00:00").unwrap(),
+//!     ],
+//!     all_dates
+//! );
 //! ```
 //!
 
@@ -103,7 +109,7 @@ mod iter;
 mod parser;
 mod validator;
 
-pub use crate::core::{Frequency, NWeekday, RRule, RRuleProperties, RRuleSet};
+pub use crate::core::{DateFilter, Frequency, NWeekday, RRule, RRuleProperties, RRuleSet};
 pub use chrono::Weekday;
 pub use error::{RRuleError, WithError};
 pub use iter::{RRuleIter, RRuleSetIter};

--- a/rrule/src/parser/rrulestr.rs
+++ b/rrule/src/parser/rrulestr.rs
@@ -1,7 +1,4 @@
-use crate::{
-    core::{DateTime, RRule, RRuleSet},
-    Frequency, NWeekday, RRuleError, RRuleProperties,
-};
+use crate::{core::DateTime, Frequency, NWeekday, RRule, RRuleError, RRuleProperties, RRuleSet};
 use chrono::{Datelike, NaiveDate, NaiveDateTime, TimeZone, Timelike, Weekday};
 use chrono_tz::{Tz, UTC};
 use lazy_static::lazy_static;
@@ -985,6 +982,7 @@ fn preprocess_rrule_string(s: &str) -> String {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::DateFilter;
 
     /// Print and compare 2 lists of dates and panic it they are not the same.
     fn check_occurrences(occurrences: Vec<DateTime>, expected: Vec<&str>) {
@@ -1206,11 +1204,12 @@ mod test {
             let tmp_now = std::time::SystemTime::now();
 
             // res.all(50);
-            res.between(
+            res.all_between(
                 UTC.timestamp_millis(915321600000),
                 UTC.timestamp_millis(920505600000),
                 true,
-            );
+            )
+            .unwrap();
             println!("All took: {:?}", tmp_now.elapsed().unwrap().as_nanos());
         }
         println!("Time took: {:?}", now.elapsed().unwrap().as_millis());
@@ -1229,7 +1228,7 @@ mod test {
 
         let res = build_rruleset("FREQ=DAILY;COUNT=7");
         assert!(res.is_ok());
-        let occurrences = res.unwrap().all(50);
+        let occurrences = res.unwrap().all(50).unwrap();
         assert_eq!(occurrences.len(), 7);
         assert!(chrono::Utc::now().timestamp() - occurrences[0].timestamp() < 2);
     }
@@ -1310,7 +1309,8 @@ mod test {
         EXDATE;TZID=Europe/Paris:20201228T093000,20210125T093000,20210208T093000"
             .parse::<RRuleSet>()
             .unwrap()
-            .all(50);
+            .all(50)
+            .unwrap();
         // This results in following set (minus exdate)
         // [
         //     2020-12-14T09:30:00CET,
@@ -1354,7 +1354,8 @@ mod test {
         RRULE:FREQ=WEEKLY;UNTIL=20210508T083000Z;INTERVAL=2;BYDAY=MO;WKST=MO"
             .parse::<RRuleSet>()
             .unwrap()
-            .all(50);
+            .all(50)
+            .unwrap();
         check_occurrences(
             dates,
             vec![

--- a/rrule/src/parser/rrulestr.rs
+++ b/rrule/src/parser/rrulestr.rs
@@ -842,6 +842,8 @@ struct ParsedInput {
     exrule_vals: Vec<RRuleProperties>,
     exdate_vals: Vec<DateTime>,
     dt_start: DateTime,
+    // TODO: Why is this field never used?
+    #[allow(dead_code)]
     tz: Tz,
 }
 

--- a/rrule/tests/common/mod.rs
+++ b/rrule/tests/common/mod.rs
@@ -3,7 +3,7 @@
 
 use chrono::{DateTime, TimeZone};
 use chrono_tz::{Tz, UTC};
-use rrule::{RRule, RRuleProperties, RRuleSet};
+use rrule::{DateFilter, RRule, RRuleProperties, RRuleSet};
 use std::fmt::Debug;
 
 pub fn ymd_hms(
@@ -19,7 +19,7 @@ pub fn ymd_hms(
 
 pub fn test_recurring_rrule(properties: RRuleProperties, expected_dates: &[DateTime<Tz>]) {
     let rrule = RRule::new(properties).unwrap();
-    let res = rrule.all(100);
+    let res = rrule.all(100).unwrap();
 
     println!("Actual: {:?}", res);
     println!("Expected: {:?}", expected_dates);
@@ -35,7 +35,7 @@ pub fn test_recurring_rrule(properties: RRuleProperties, expected_dates: &[DateT
 }
 
 pub fn test_recurring_rrule_set(rrule_set: RRuleSet, expected_dates: &[DateTime<Tz>]) {
-    let res = rrule_set.all(100);
+    let res = rrule_set.all(100).unwrap();
 
     println!("Actual: {:?}", res);
     println!("Expected: {:?}", expected_dates);

--- a/rrule/tests/datetime.rs
+++ b/rrule/tests/datetime.rs
@@ -2,7 +2,7 @@ mod common;
 
 use chrono::TimeZone;
 use chrono_tz::UTC;
-use rrule::{RRule, RRuleError};
+use rrule::{DateFilter, RRule, RRuleError};
 use std::str::FromStr;
 
 /// Check if datetime can be parsed correctly
@@ -13,7 +13,7 @@ fn parse_datetime() {
         .expect("RRule could not be parsed");
 
     assert_eq!(
-        rrule.all(50),
+        rrule.all(50).unwrap(),
         vec![
             UTC.ymd(2012, 2, 1).and_hms(2, 30, 0),
             UTC.ymd(2012, 2, 2).and_hms(2, 30, 0)
@@ -30,7 +30,7 @@ fn parse_datetime_with_timezone() {
             .expect("RRule could not be parsed");
 
     assert_eq!(
-        rrule.all(50),
+        rrule.all(50).unwrap(),
         vec![
             UTC.ymd(2012, 2, 1).and_hms(2, 30, 0),
             UTC.ymd(2012, 2, 2).and_hms(2, 30, 0)
@@ -95,7 +95,8 @@ fn monthly_on_31th() {
         RRULE:FREQ=MONTHLY;COUNT=10;BYMONTHDAY=31"
         .parse::<RRule>()
         .unwrap()
-        .all(20);
+        .all(20)
+        .unwrap();
     // TODO: Is this the correct behavior?
     common::check_occurrences(
         &dates,
@@ -121,7 +122,8 @@ fn monthly_on_31th_to_last() {
         RRULE:FREQ=MONTHLY;COUNT=10;BYMONTHDAY=-31"
         .parse::<RRule>()
         .unwrap()
-        .all(20);
+        .all(20)
+        .unwrap();
     // TODO: Is this the correct behavior?
     common::check_occurrences(
         &dates,

--- a/rrule/tests/rfc_tests.rs
+++ b/rrule/tests/rfc_tests.rs
@@ -3,7 +3,7 @@
 
 mod common;
 
-use rrule::{RRule, RRuleSet};
+use rrule::{DateFilter, RRule, RRuleSet};
 
 // ------------------------------------------ Daily ---------------------------------------------
 
@@ -14,7 +14,8 @@ fn daily_10_occurrences() {
         RRULE:FREQ=DAILY;COUNT=10"
         .parse::<RRule>()
         .unwrap()
-        .all(50);
+        .all(50)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -41,7 +42,8 @@ fn daily_until_november() {
         RRULE:FREQ=DAILY;UNTIL=19971103T000000Z"
         .parse::<RRule>()
         .unwrap()
-        .all(60);
+        .all(60)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -104,7 +106,8 @@ fn every_other_day() {
         RRULE:FREQ=DAILY;INTERVAL=2"
         .parse::<RRule>()
         .unwrap()
-        .all(32);
+        .all(32)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -151,7 +154,8 @@ fn every_10_days_5_occurrences() {
         RRULE:FREQ=DAILY;INTERVAL=10;COUNT=5"
         .parse::<RRule>()
         .unwrap()
-        .all(50);
+        .all(50)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -172,12 +176,14 @@ fn every_days_in_jan_for_3_years() {
         RRULE:FREQ=YEARLY;UNTIL=20000131T140000Z;BYMONTH=1;BYDAY=SU,MO,TU,WE,TH,FR,SA"
         .parse::<RRule>()
         .unwrap()
-        .all(100);
+        .all(100)
+        .unwrap();
     let dates_alt = "DTSTART;TZID=America/New_York:19980101T090000\n\
         RRULE:FREQ=DAILY;UNTIL=20000131T140000Z;BYMONTH=1"
         .parse::<RRule>()
         .unwrap()
-        .all(100);
+        .all(100)
+        .unwrap();
     let mut expected = vec![];
     for year in 1998..=2000 {
         for day in 1..=31 {
@@ -197,7 +203,8 @@ fn weekly_10_occurrences() {
         RRULE:FREQ=WEEKLY;COUNT=10"
         .parse::<RRule>()
         .unwrap()
-        .all(50);
+        .all(50)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -224,7 +231,8 @@ fn weekly_until_november() {
         RRULE:FREQ=WEEKLY;UNTIL=19971105T000000Z"
         .parse::<RRule>()
         .unwrap()
-        .all(60);
+        .all(60)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -250,7 +258,8 @@ fn every_other_week() {
         RRULE:FREQ=WEEKLY;INTERVAL=2;WKST=SU"
         .parse::<RRule>()
         .unwrap()
-        .all(13);
+        .all(13)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -278,12 +287,14 @@ fn weekly_on_tue_and_thu_for_5_weeks() {
         RRULE:FREQ=WEEKLY;UNTIL=19971007T000000Z;WKST=SU;BYDAY=TU,TH"
         .parse::<RRule>()
         .unwrap()
-        .all(50);
+        .all(50)
+        .unwrap();
     let dates_alt = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=WEEKLY;COUNT=10;WKST=SU;BYDAY=TU,TH"
         .parse::<RRule>()
         .unwrap()
-        .all(50);
+        .all(50)
+        .unwrap();
     let expected = vec![
         "1997-09-02T09:00:00-04:00",
         "1997-09-04T09:00:00-04:00",
@@ -308,7 +319,8 @@ fn every_other_week_some_days_until_dec() {
         RRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=19971224T000000Z;WKST=SU;BYDAY=MO,WE,FR"
         .parse::<RRule>()
         .unwrap()
-        .all(50);
+        .all(50)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -348,7 +360,8 @@ fn every_other_week_some_days_8_occurrences() {
         RRULE:FREQ=WEEKLY;INTERVAL=2;COUNT=8;WKST=SU;BYDAY=TU,TH"
         .parse::<RRule>()
         .unwrap()
-        .all(50);
+        .all(50)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -373,7 +386,8 @@ fn monthly_on_first_friday_10_occurrences() {
         RRULE:FREQ=MONTHLY;COUNT=10;BYDAY=1FR"
         .parse::<RRule>()
         .unwrap()
-        .all(50);
+        .all(50)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -398,7 +412,8 @@ fn monthly_on_first_friday_until_dec() {
         RRULE:FREQ=MONTHLY;UNTIL=19971224T000000Z;BYDAY=1FR"
         .parse::<RRule>()
         .unwrap()
-        .all(50);
+        .all(50)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -417,7 +432,8 @@ fn every_other_month_on_first_and_last_sunday_10_occurrences() {
         RRULE:FREQ=MONTHLY;INTERVAL=2;COUNT=10;BYDAY=1SU,-1SU"
         .parse::<RRule>()
         .unwrap()
-        .all(50);
+        .all(50)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -442,7 +458,8 @@ fn monthly_on_second_to_last_monday_for_6_months() {
         RRULE:FREQ=MONTHLY;COUNT=6;BYDAY=-2MO"
         .parse::<RRule>()
         .unwrap()
-        .all(50);
+        .all(50)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -463,7 +480,8 @@ fn monthly_on_third_to_last_day_forever() {
         RRULE:FREQ=MONTHLY;BYMONTHDAY=-3"
         .parse::<RRule>()
         .unwrap()
-        .all(6);
+        .all(6)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -484,7 +502,8 @@ fn monthly_on_2nd_and_15th_10_occurrences() {
         RRULE:FREQ=MONTHLY;COUNT=10;BYMONTHDAY=2,15"
         .parse::<RRule>()
         .unwrap()
-        .all(20);
+        .all(20)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -509,7 +528,8 @@ fn monthly_on_first_and_last_day_10_occurrences() {
         RRULE:FREQ=MONTHLY;COUNT=10;BYMONTHDAY=1,-1"
         .parse::<RRule>()
         .unwrap()
-        .all(20);
+        .all(20)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -534,7 +554,8 @@ fn every_18_months_10th_to_15th_10_occurrences() {
         RRULE:FREQ=MONTHLY;INTERVAL=18;COUNT=10;BYMONTHDAY=10,11,12,13,14,15"
         .parse::<RRule>()
         .unwrap()
-        .all(20);
+        .all(20)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -559,7 +580,8 @@ fn every_tuesday_every_other_month() {
         RRULE:FREQ=MONTHLY;INTERVAL=2;BYDAY=TU"
         .parse::<RRule>()
         .unwrap()
-        .all(18);
+        .all(18)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -597,7 +619,8 @@ fn yearly_in_june_and_july_for_10_occurrences() {
         RRULE:FREQ=YEARLY;COUNT=10;BYMONTH=6,7"
         .parse::<RRule>()
         .unwrap()
-        .all(20);
+        .all(20)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -622,7 +645,8 @@ fn every_other_year_on_jan_feb_and_march_for_10_occurrences() {
         RRULE:FREQ=YEARLY;INTERVAL=2;COUNT=10;BYMONTH=1,2,3"
         .parse::<RRule>()
         .unwrap()
-        .all(20);
+        .all(20)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -647,7 +671,8 @@ fn every_third_year_on_1st_100th_and_200th_day_for_10_occurrences() {
         RRULE:FREQ=YEARLY;INTERVAL=3;COUNT=10;BYYEARDAY=1,100,200"
         .parse::<RRule>()
         .unwrap()
-        .all(20);
+        .all(20)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -672,7 +697,8 @@ fn every_20th_monday_of_year_forever() {
         RRULE:FREQ=YEARLY;BYDAY=20MO"
         .parse::<RRule>()
         .unwrap()
-        .all(3);
+        .all(3)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -690,7 +716,8 @@ fn monday_of_week_20_forever() {
         RRULE:FREQ=YEARLY;BYWEEKNO=20;BYDAY=MO"
         .parse::<RRule>()
         .unwrap()
-        .all(3);
+        .all(3)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -708,7 +735,8 @@ fn every_thursday_in_march_forever() {
         RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=TH"
         .parse::<RRule>()
         .unwrap()
-        .all(11);
+        .all(11)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -734,7 +762,8 @@ fn every_thursday_only_during_june_july_and_august_forever() {
         RRULE:FREQ=YEARLY;BYDAY=TH;BYMONTH=6,7,8"
         .parse::<RRule>()
         .unwrap()
-        .all(39);
+        .all(39)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -789,7 +818,8 @@ fn every_friday_the_13th_forever() {
         RRULE:FREQ=MONTHLY;BYDAY=FR;BYMONTHDAY=13"
         .parse::<RRuleSet>()
         .unwrap()
-        .all(5);
+        .all(5)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -809,7 +839,8 @@ fn first_sat_follows_first_sunday_of_month_forever() {
         RRULE:FREQ=MONTHLY;BYDAY=SA;BYMONTHDAY=7,8,9,10,11,12,13"
         .parse::<RRule>()
         .unwrap()
-        .all(10);
+        .all(10)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -835,7 +866,8 @@ fn every_4_years_us_presidential_election_day_forever() {
         RRULE:FREQ=YEARLY;INTERVAL=4;BYMONTH=11;BYDAY=TU;BYMONTHDAY=2,3,4,5,6,7,8"
         .parse::<RRule>()
         .unwrap()
-        .all(3);
+        .all(3)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -855,7 +887,8 @@ fn every_third_instance_of_weekday_in_month_for_3_months() {
         RRULE:FREQ=MONTHLY;COUNT=3;BYDAY=TU,WE,TH;BYSETPOS=3"
         .parse::<RRule>()
         .unwrap()
-        .all(10);
+        .all(10)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -874,7 +907,8 @@ fn second_to_last_weekday_of_month() {
         RRULE:FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=-2"
         .parse::<RRule>()
         .unwrap()
-        .all(7);
+        .all(7)
+        .unwrap();
     // All seem to be 1 day off
     common::check_occurrences(
         &dates,
@@ -898,7 +932,8 @@ fn every_3_hours_on_specific_day() {
         RRULE:FREQ=HOURLY;INTERVAL=3;UNTIL=19970902T170000Z"
         .parse::<RRule>()
         .unwrap()
-        .all(10);
+        .all(10)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -916,7 +951,8 @@ fn every_15_min_for_6_occurrences() {
         RRULE:FREQ=MINUTELY;INTERVAL=15;COUNT=6"
         .parse::<RRule>()
         .unwrap()
-        .all(10);
+        .all(10)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -937,7 +973,8 @@ fn every_hour_and_a_half_for_4_occurrences() {
         RRULE:FREQ=MINUTELY;INTERVAL=90;COUNT=4"
         .parse::<RRule>()
         .unwrap()
-        .all(10);
+        .all(10)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -956,12 +993,14 @@ fn every_20_min_at_time_every_day() {
         RRULE:FREQ=DAILY;BYHOUR=9,10,11,12,13,14,15,16;BYMINUTE=0,20,40"
         .parse::<RRule>()
         .unwrap()
-        .all(72);
+        .all(72)
+        .unwrap();
     let dates_alt = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=MINUTELY;INTERVAL=20;BYHOUR=9,10,11,12,13,14,15,16"
         .parse::<RRule>()
         .unwrap()
-        .all(72);
+        .all(72)
+        .unwrap();
 
     let mut expected = vec![];
     for day in 2..=4 {
@@ -1003,7 +1042,8 @@ fn week_day_start_monday_generated_days() {
         RRULE:FREQ=WEEKLY;INTERVAL=2;COUNT=4;BYDAY=TU,SU;WKST=MO"
         .parse::<RRule>()
         .unwrap()
-        .all(10);
+        .all(10)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -1022,7 +1062,8 @@ fn week_day_start_sunday_generated_days() {
         RRULE:FREQ=WEEKLY;INTERVAL=2;COUNT=4;BYDAY=TU,SU;WKST=SU"
         .parse::<RRule>()
         .unwrap()
-        .all(10);
+        .all(10)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[
@@ -1041,7 +1082,8 @@ fn invalid_date_is_ignored() {
         RRULE:FREQ=MONTHLY;BYMONTHDAY=15,30;COUNT=5"
         .parse::<RRule>()
         .unwrap()
-        .all(10);
+        .all(10)
+        .unwrap();
     common::check_occurrences(
         &dates,
         &[

--- a/rrule/tests/rrule.rs
+++ b/rrule/tests/rrule.rs
@@ -3,7 +3,7 @@ mod common;
 use chrono::{Datelike, TimeZone};
 use chrono_tz::UTC;
 use common::{test_recurring_rrule, ymd_hms};
-use rrule::{Frequency, NWeekday, RRule, RRuleProperties, Weekday};
+use rrule::{DateFilter, Frequency, NWeekday, RRule, RRuleProperties, Weekday};
 
 #[test]
 fn yearly() {
@@ -4684,7 +4684,7 @@ fn test_before_inclusive_hit() {
     let before = UTC.ymd(2012, 2, 2).and_hms(9, 30, 0);
     let inc = true;
 
-    assert_eq!(Some(before), rrule.before(before, inc));
+    assert_eq!(Some(before), rrule.just_before(before, inc).unwrap());
 }
 
 #[test]
@@ -4697,7 +4697,7 @@ fn test_before_inclusive_miss() {
     let oracle = UTC.ymd(2012, 2, 2).and_hms(9, 30, 0);
     let inc = true;
 
-    assert_eq!(Some(oracle), rrule.before(before, inc));
+    assert_eq!(Some(oracle), rrule.just_before(before, inc).unwrap());
 }
 
 #[test]
@@ -4709,7 +4709,7 @@ fn test_after_inclusive_hit() {
     let after = UTC.ymd(2012, 2, 2).and_hms(9, 30, 0);
     let inc = true;
 
-    assert_eq!(Some(after), rrule.after(after, inc));
+    assert_eq!(Some(after), rrule.just_after(after, inc).unwrap());
 }
 
 #[test]
@@ -4722,7 +4722,7 @@ fn test_after_inclusive_miss() {
     let oracle = UTC.ymd(2012, 2, 3).and_hms(9, 30, 0);
     let inc = true;
 
-    assert_eq!(Some(oracle), rrule.after(after, inc));
+    assert_eq!(Some(oracle), rrule.just_after(after, inc).unwrap());
 }
 
 #[test]
@@ -4736,7 +4736,7 @@ fn test_between_inclusive_both_miss() {
     let after = UTC.ymd(2012, 2, 4).and_hms(9, 0, 0);
     let inc = true;
 
-    assert_eq!(vec![middle], rrule.between(before, after, inc));
+    assert_eq!(vec![middle], rrule.all_between(before, after, inc).unwrap());
 }
 
 #[test]
@@ -4750,7 +4750,10 @@ fn test_between_inclusive_lower_miss() {
     let after = UTC.ymd(2012, 2, 4).and_hms(9, 30, 0);
     let inc = true;
 
-    assert_eq!(vec![middle, after], rrule.between(before, after, inc));
+    assert_eq!(
+        vec![middle, after],
+        rrule.all_between(before, after, inc).unwrap()
+    );
 }
 
 #[test]
@@ -4764,7 +4767,10 @@ fn test_between_inclusive_upper_miss() {
     let after = UTC.ymd(2012, 2, 4).and_hms(9, 0, 0);
     let inc = true;
 
-    assert_eq!(vec![before, middle], rrule.between(before, after, inc));
+    assert_eq!(
+        vec![before, middle],
+        rrule.all_between(before, after, inc).unwrap()
+    );
 }
 
 #[test]
@@ -4780,6 +4786,6 @@ fn test_between_inclusive_both_hit() {
 
     assert_eq!(
         vec![before, middle, after],
-        rrule.between(before, after, inc)
+        rrule.all_between(before, after, inc).unwrap()
     );
 }

--- a/rrule/tests/rrule_set.rs
+++ b/rrule/tests/rrule_set.rs
@@ -3,7 +3,7 @@ mod common;
 use chrono::TimeZone;
 use chrono_tz::UTC;
 use common::{test_recurring_rrule_set, ymd_hms};
-use rrule::{Frequency, NWeekday, RRule, RRuleProperties, RRuleSet, Weekday};
+use rrule::{DateFilter, Frequency, NWeekday, RRule, RRuleProperties, RRuleSet, Weekday};
 
 #[test]
 fn rrule_and_exrule() {
@@ -208,7 +208,9 @@ fn before() {
     set.exrule(rrule);
 
     assert_eq!(
-        set.before(ymd_hms(2015, 9, 2, 9, 0, 0), false).unwrap(),
+        set.just_before(ymd_hms(2015, 9, 2, 9, 0, 0), false)
+            .unwrap()
+            .unwrap(),
         ymd_hms(2014, 9, 2, 9, 0, 0),
     );
 }
@@ -245,7 +247,9 @@ fn after() {
     set.exrule(rrule);
 
     assert_eq!(
-        set.after(ymd_hms(2000, 9, 2, 9, 0, 0), false).unwrap(),
+        set.just_after(ymd_hms(2000, 9, 2, 9, 0, 0), false)
+            .unwrap()
+            .unwrap(),
         ymd_hms(2007, 9, 2, 9, 0, 0),
     );
 }
@@ -282,11 +286,12 @@ fn between() {
     set.exrule(rrule);
 
     common::check_occurrences(
-        &set.between(
+        &set.all_between(
             ymd_hms(2000, 9, 2, 9, 0, 0),
             ymd_hms(2010, 9, 2, 9, 0, 0),
             false,
-        ),
+        )
+        .unwrap(),
         &[
             "2007-09-02T09:00:00-00:00",
             "2008-09-02T09:00:00-00:00",


### PR DESCRIPTION
- Added new trait `DateFilter` for implementing methods like:
`all_with_error`, `all_before_with_error`, `all_after_with_error` and `all_between_with_error` and moved/added methods like `all`, `just_before`, etc.
- Function `all` was moved to `DateFilter` and returns a `Result` now.
- Removed function `between`, use `DateFilter::all_between` instead.
- Removed function `after`, use `DateFilter::just_after` instead.
- Removed function `before`, use `DateFilter::just_before` instead.

This allows for a shared codebase for `RRule` and `RRuleSet` functions and improved error reporting.
More functions return `Result` instead of just silently returning less or no dates.

All functions like `all`, `just_before`, `all_after_with_error` also use a shared codebase so this should reduce potential errors and result in common behavior.

Some now functions for `_with_error` variant of functions where added.

Let me know if there are any remarks.