### PR TITLE
Draft: Introduce new `DateTime`

### DIFF
--- a/rrule-debugger/src/main.rs
+++ b/rrule-debugger/src/main.rs
@@ -5,10 +5,9 @@ mod iter_rrule;
 mod parser_rrule;
 mod simple_logger;
 
-use chrono::DateTime;
-use chrono_tz::Tz;
 use clap::Parser;
 use log::LevelFilter;
+use rrule::DateTime;
 
 const CRASHES_PATH: &str = "rrule-afl-fuzz/out/default/crashes/";
 
@@ -122,8 +121,8 @@ fn read_all_crash_file() -> Vec<Vec<u8>> {
     list
 }
 
-pub fn print_all_datetimes(list: &[DateTime<Tz>]) {
-    let formatter = |dt: &DateTime<Tz>| -> String { format!("    \"{}\",\n", dt.to_rfc3339()) };
+pub fn print_all_datetimes(list: &[DateTime]) {
+    let formatter = |dt: &DateTime| -> String { format!("    \"{}\",\n", dt.to_rfc3339()) };
     println!("[\n{}]", list.iter().map(formatter).collect::<String>(),);
 }
 

--- a/rrule/examples/manual_iter.rs
+++ b/rrule/examples/manual_iter.rs
@@ -2,7 +2,6 @@
 //!
 //! Manually iterate over an `RRule`.
 
-use chrono::Datelike;
 use rrule::RRuleSet;
 
 fn main() {

--- a/rrule/examples/manual_rrule.rs
+++ b/rrule/examples/manual_rrule.rs
@@ -2,7 +2,7 @@
 //!
 //! Create an [`RRule`] object.
 
-use chrono::{Datelike, TimeZone, Timelike};
+use chrono::TimeZone;
 use chrono_tz::UTC;
 use rrule::{Frequency, RRule};
 

--- a/rrule/src/core/datetime.rs
+++ b/rrule/src/core/datetime.rs
@@ -82,10 +82,36 @@ impl RRuleTimeZone {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Copy)]
+/// DateTime that is able to represent datetimes in Local and chrono_tz::Tz
+/// timezones.
+#[derive(Debug, Clone, Eq, Ord, Copy)]
 pub enum DateTime {
+    /// Local timezone
     Local(chrono::DateTime<chrono::Local>),
+    /// Specific non-local timezone
     Tz(chrono::DateTime<chrono_tz::Tz>),
+}
+
+impl PartialEq for DateTime {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Local(l0), Self::Local(r0)) => l0 == r0,
+            (Self::Tz(l0), Self::Tz(r0)) => l0 == r0,
+            (Self::Tz(l0), Self::Local(r0)) => l0 == r0,
+            (Self::Local(l0), Self::Tz(r0)) => l0 == r0,
+        }
+    }
+}
+
+impl PartialOrd for DateTime {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        match (self, other) {
+            (Self::Local(l0), Self::Local(r0)) => l0.partial_cmp(r0),
+            (Self::Tz(l0), Self::Tz(r0)) => l0.partial_cmp(r0),
+            (Self::Tz(l0), Self::Local(r0)) => l0.partial_cmp(r0),
+            (Self::Local(l0), Self::Tz(r0)) => l0.partial_cmp(r0),
+        }
+    }
 }
 
 impl DateTime {
@@ -98,7 +124,7 @@ impl DateTime {
 
     pub fn timezone(&self) -> RRuleTimeZone {
         match self {
-            Self::Local(dt) => RRuleTimeZone::Local,
+            Self::Local(_) => RRuleTimeZone::Local,
             Self::Tz(dt) => RRuleTimeZone::Tz(dt.timezone()),
         }
     }

--- a/rrule/src/core/datetime.rs
+++ b/rrule/src/core/datetime.rs
@@ -1,4 +1,4 @@
-use chrono::{Datelike, Duration, NaiveTime, TimeZone, Timelike};
+use chrono::{Datelike, Duration, NaiveTime, TimeZone, Timelike, Weekday};
 use chrono_tz::Tz;
 
 pub(crate) fn duration_from_midnight(time: NaiveTime) -> Duration {
@@ -34,22 +34,38 @@ pub(crate) fn datetime_to_ical_format(dt: &DateTime) -> String {
     let mut tz_prefix = String::new();
     let mut tz_postfix = String::new();
     let tz = dt.timezone();
-    if tz == Tz::UTC {
-        tz_postfix = "Z".to_string();
-    } else {
-        tz_prefix = format!(";TZID={}", tz.name());
-    };
+    match tz {
+        RRuleTimeZone::Local => {}
+        RRuleTimeZone::Tz(tz) => match tz {
+            Tz::UTC => {
+                tz_postfix = "Z".to_string();
+            }
+            _ => {
+                tz_prefix = format!(";TZID={}", tz.name());
+            }
+        },
+    }
 
     let dt = dt.format("%Y%m%dT%H%M%S");
     format!("{}:{}{}", tz_prefix, dt, tz_postfix)
 }
 
+#[derive(Debug, PartialEq)]
 pub(crate) enum RRuleTimeZone {
     Local,
     Tz(chrono_tz::Tz),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+impl RRuleTimeZone {
+    pub fn name(&self) -> String {
+        match self {
+            RRuleTimeZone::Local => "Local".into(),
+            RRuleTimeZone::Tz(tz) => tz.name().into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum DateTime {
     Local(chrono::DateTime<chrono::Local>),
     Tz(chrono::DateTime<chrono_tz::Tz>),
@@ -67,6 +83,55 @@ impl DateTime {
         match self {
             Self::Local(dt) => RRuleTimeZone::Local,
             Self::Tz(dt) => RRuleTimeZone::Tz(dt.timezone()),
+        }
+    }
+
+    pub fn year(&self) -> i32 {
+        match self {
+            Self::Local(dt) => dt.year(),
+            Self::Tz(dt) => dt.year(),
+        }
+    }
+
+    pub fn month(&self) -> u32 {
+        match self {
+            Self::Local(dt) => dt.month(),
+            Self::Tz(dt) => dt.month(),
+        }
+    }
+
+    pub fn weekday(&self) -> Weekday {
+        match self {
+            Self::Local(dt) => dt.weekday(),
+            Self::Tz(dt) => dt.weekday(),
+        }
+    }
+
+    pub fn day(&self) -> u32 {
+        match self {
+            Self::Local(dt) => dt.day(),
+            Self::Tz(dt) => dt.day(),
+        }
+    }
+
+    pub fn hour(&self) -> u32 {
+        match self {
+            Self::Local(dt) => dt.hour(),
+            Self::Tz(dt) => dt.hour(),
+        }
+    }
+
+    pub fn minute(&self) -> u32 {
+        match self {
+            Self::Local(dt) => dt.minute(),
+            Self::Tz(dt) => dt.minute(),
+        }
+    }
+
+    pub fn second(&self) -> u32 {
+        match self {
+            Self::Local(dt) => dt.second(),
+            Self::Tz(dt) => dt.second(),
         }
     }
 

--- a/rrule/src/core/mod.rs
+++ b/rrule/src/core/mod.rs
@@ -7,6 +7,7 @@ pub use self::rrule::{Frequency, NWeekday, RRule};
 pub use self::rruleset::RRuleSet;
 pub(crate) use datetime::{
     duration_from_midnight, get_day, get_hour, get_minute, get_month, get_second, DateTime,
+    RRuleTimeZone,
 };
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]

--- a/rrule/src/core/mod.rs
+++ b/rrule/src/core/mod.rs
@@ -5,9 +5,9 @@ pub(crate) mod utils;
 
 pub use self::rrule::{Frequency, NWeekday, RRule};
 pub use self::rruleset::RRuleSet;
+pub use datetime::DateTime;
 pub(crate) use datetime::{
-    duration_from_midnight, get_day, get_hour, get_minute, get_month, get_second, DateTime,
-    RRuleTimeZone,
+    duration_from_midnight, get_day, get_hour, get_minute, get_month, get_second, RRuleTimeZone,
 };
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]

--- a/rrule/src/core/rrule.rs
+++ b/rrule/src/core/rrule.rs
@@ -8,7 +8,7 @@ use crate::parser::str_to_weekday;
 use crate::parser::ParseError;
 use crate::validator::validate_rrule;
 use crate::{RRuleError, RRuleIter, RRuleSet, Unvalidated, Validated};
-use chrono::{Datelike, Month, Weekday};
+use chrono::{Month, Weekday};
 use chrono_tz::Tz;
 #[cfg(feature = "serde")]
 use serde_with::{DeserializeFromStr, SerializeDisplay};

--- a/rrule/src/core/rrule.rs
+++ b/rrule/src/core/rrule.rs
@@ -332,7 +332,7 @@ impl RRule<Unvalidated> {
     /// upper-bound limit of the recurrence.
     #[must_use]
     pub fn until(mut self, until: chrono::DateTime<Tz>) -> Self {
-        self.until = Some(until);
+        self.until = Some(until.into());
         self
     }
 

--- a/rrule/src/core/rrule.rs
+++ b/rrule/src/core/rrule.rs
@@ -542,7 +542,11 @@ impl RRule<Unvalidated> {
     /// # Errors
     ///
     /// If the properties are not valid it will return [`RRuleError`].
-    pub fn validate(self, dt_start: DateTime) -> Result<RRule<Validated>, RRuleError> {
+    pub fn validate<T>(self, dt_start: T) -> Result<RRule<Validated>, RRuleError>
+    where
+        DateTime: From<T>,
+    {
+        let dt_start = dt_start.into();
         let rrule = self.finalize_parsed_rrule(&dt_start);
 
         // Validate required checks (defined by RFC 5545)
@@ -574,7 +578,11 @@ impl RRule<Unvalidated> {
     /// # Errors
     ///
     /// Returns [`RRuleError::ValidationError`] in case the rrule is invalid.
-    pub fn build(self, dt_start: DateTime) -> Result<RRuleSet, RRuleError> {
+    pub fn build<T>(self, dt_start: T) -> Result<RRuleSet, RRuleError>
+    where
+        DateTime: From<T>,
+        T: Copy,
+    {
         let rrule = self.validate(dt_start)?;
         let rrule_set = RRuleSet::new(dt_start).rrule(rrule);
         Ok(rrule_set)

--- a/rrule/src/core/rruleset.rs
+++ b/rrule/src/core/rruleset.rs
@@ -32,9 +32,12 @@ pub struct RRuleSet {
 impl RRuleSet {
     /// Creates an empty [`RRuleSet`], starting from `ds_start`.
     #[must_use]
-    pub fn new(dt_start: DateTime) -> Self {
+    pub fn new<T>(dt_start: T) -> Self
+    where
+        DateTime: From<T>,
+    {
         Self {
-            dt_start,
+            dt_start: dt_start.into(),
             rrule: vec![],
             rdate: vec![],
             exrule: vec![],
@@ -79,15 +82,21 @@ impl RRuleSet {
 
     /// Adds a new rdate to the set.
     #[must_use]
-    pub fn rdate(mut self, rdate: DateTime) -> Self {
-        self.rdate.push(rdate);
+    pub fn rdate<T>(mut self, rdate: T) -> Self
+    where
+        DateTime: From<T>,
+    {
+        self.rdate.push(rdate.into());
         self
     }
 
     /// Adds a new exdate to the set.
     #[must_use]
-    pub fn exdate(mut self, exdate: DateTime) -> Self {
-        self.exdate.push(exdate);
+    pub fn exdate<T>(mut self, exdate: T) -> Self
+    where
+        DateTime: From<T>,
+    {
+        self.exdate.push(exdate.into());
         self
     }
 

--- a/rrule/src/core/rruleset.rs
+++ b/rrule/src/core/rruleset.rs
@@ -51,8 +51,11 @@ impl RRuleSet {
     ///
     /// This value will not be used if you use the `Iterator` API directly.
     #[must_use]
-    pub fn before(mut self, dt: DateTime) -> Self {
-        self.before = Some(dt);
+    pub fn before<T>(mut self, dt: T) -> Self
+    where
+        DateTime: From<T>,
+    {
+        self.before = Some(dt.into());
         self
     }
 
@@ -60,8 +63,11 @@ impl RRuleSet {
     ///
     /// This value will not be used if you use the `Iterator` API directly.
     #[must_use]
-    pub fn after(mut self, dt: DateTime) -> Self {
-        self.after = Some(dt);
+    pub fn after<T>(mut self, dt: T) -> Self
+    where
+        DateTime: From<T>,
+    {
+        self.after = Some(dt.into());
         self
     }
 
@@ -117,15 +123,21 @@ impl RRuleSet {
 
     /// Sets the rdates of the set.
     #[must_use]
-    pub fn set_rdates(mut self, rdates: Vec<DateTime>) -> Self {
-        self.rdate = rdates;
+    pub fn set_rdates<T>(mut self, rdates: Vec<T>) -> Self
+    where
+        DateTime: From<T>,
+    {
+        self.rdate = rdates.into_iter().map(From::from).collect();
         self
     }
 
     /// Set the exdates of the set.
     #[must_use]
-    pub fn set_exdates(mut self, exdates: Vec<DateTime>) -> Self {
-        self.exdate = exdates;
+    pub fn set_exdates<T>(mut self, exdates: Vec<T>) -> Self
+    where
+        DateTime: From<T>,
+    {
+        self.exdate = exdates.into_iter().map(From::from).collect();
         self
     }
 

--- a/rrule/src/core/utils.rs
+++ b/rrule/src/core/utils.rs
@@ -127,26 +127,26 @@ mod tests {
     #[test]
     fn in_range_exclusive_start_to_end() {
         let inclusive = false;
-        let start = UTC.ymd(2021, 10, 1).and_hms(8, 0, 0);
-        let end = UTC.ymd(2021, 10, 1).and_hms(10, 0, 0);
+        let start = UTC.ymd(2021, 10, 1).and_hms(8, 0, 0).into();
+        let end = UTC.ymd(2021, 10, 1).and_hms(10, 0, 0).into();
 
         // In middle
         assert!(is_in_range(
-            &UTC.ymd(2021, 10, 1).and_hms(9, 0, 0),
+            &UTC.ymd(2021, 10, 1).and_hms(9, 0, 0).into(),
             &Some(start),
             &Some(end),
             inclusive
         ));
         // To small
         assert!(!is_in_range(
-            &UTC.ymd(2021, 10, 1).and_hms(7, 0, 0),
+            &UTC.ymd(2021, 10, 1).and_hms(7, 0, 0).into(),
             &Some(start),
             &Some(end),
             inclusive
         ));
         // To big
         assert!(!is_in_range(
-            &UTC.ymd(2021, 10, 1).and_hms(11, 0, 0),
+            &UTC.ymd(2021, 10, 1).and_hms(11, 0, 0).into(),
             &Some(start),
             &Some(end),
             inclusive
@@ -160,25 +160,25 @@ mod tests {
     #[test]
     fn in_range_exclusive_start() {
         let inclusive = false;
-        let start = UTC.ymd(2021, 10, 1).and_hms(8, 0, 0);
+        let start = UTC.ymd(2021, 10, 1).and_hms(8, 0, 0).into();
 
         // Just after
         assert!(is_in_range(
-            &UTC.ymd(2021, 10, 1).and_hms(9, 0, 0),
+            &UTC.ymd(2021, 10, 1).and_hms(9, 0, 0).into(),
             &Some(start),
             &None,
             inclusive
         ));
         // To small
         assert!(!is_in_range(
-            &UTC.ymd(2021, 10, 1).and_hms(7, 0, 0),
+            &UTC.ymd(2021, 10, 1).and_hms(7, 0, 0).into(),
             &Some(start),
             &None,
             inclusive
         ));
         // Bigger
         assert!(is_in_range(
-            &UTC.ymd(2021, 10, 2).and_hms(8, 0, 0),
+            &UTC.ymd(2021, 10, 2).and_hms(8, 0, 0).into(),
             &Some(start),
             &None,
             inclusive
@@ -190,25 +190,25 @@ mod tests {
     #[test]
     fn in_range_exclusive_end() {
         let inclusive = false;
-        let end = UTC.ymd(2021, 10, 1).and_hms(10, 0, 0);
+        let end = UTC.ymd(2021, 10, 1).and_hms(10, 0, 0).into();
 
         // Just before
         assert!(is_in_range(
-            &UTC.ymd(2021, 10, 1).and_hms(9, 0, 0),
+            &UTC.ymd(2021, 10, 1).and_hms(9, 0, 0).into(),
             &None,
             &Some(end),
             inclusive
         ));
         // Smaller
         assert!(is_in_range(
-            &UTC.ymd(2021, 9, 20).and_hms(10, 0, 0),
+            &UTC.ymd(2021, 9, 20).and_hms(10, 0, 0).into(),
             &None,
             &Some(end),
             inclusive
         ));
         // Bigger
         assert!(!is_in_range(
-            &UTC.ymd(2021, 10, 2).and_hms(8, 0, 0),
+            &UTC.ymd(2021, 10, 2).and_hms(8, 0, 0).into(),
             &None,
             &Some(end),
             inclusive
@@ -223,21 +223,21 @@ mod tests {
 
         // Some date
         assert!(is_in_range(
-            &UTC.ymd(2021, 10, 1).and_hms(9, 0, 0),
+            &UTC.ymd(2021, 10, 1).and_hms(9, 0, 0).into(),
             &None,
             &None,
             inclusive
         ));
         // Smaller
         assert!(is_in_range(
-            &UTC.ymd(2021, 9, 20).and_hms(10, 0, 0),
+            &UTC.ymd(2021, 9, 20).and_hms(10, 0, 0).into(),
             &None,
             &None,
             inclusive
         ));
         // Bigger
         assert!(is_in_range(
-            &UTC.ymd(2021, 10, 2).and_hms(8, 0, 0),
+            &UTC.ymd(2021, 10, 2).and_hms(8, 0, 0).into(),
             &None,
             &None,
             inclusive
@@ -249,26 +249,26 @@ mod tests {
     #[test]
     fn in_range_inclusive_start_to_end() {
         let inclusive = true;
-        let start = UTC.ymd(2021, 10, 1).and_hms(8, 0, 0);
-        let end = UTC.ymd(2021, 10, 1).and_hms(10, 0, 0);
+        let start = UTC.ymd(2021, 10, 1).and_hms(8, 0, 0).into();
+        let end = UTC.ymd(2021, 10, 1).and_hms(10, 0, 0).into();
 
         // In middle
         assert!(is_in_range(
-            &UTC.ymd(2021, 10, 1).and_hms(9, 0, 0),
+            &UTC.ymd(2021, 10, 1).and_hms(9, 0, 0).into(),
             &Some(start),
             &Some(end),
             inclusive
         ));
         // To small
         assert!(!is_in_range(
-            &UTC.ymd(2021, 10, 1).and_hms(7, 0, 0),
+            &UTC.ymd(2021, 10, 1).and_hms(7, 0, 0).into(),
             &Some(start),
             &Some(end),
             inclusive
         ));
         // To big
         assert!(!is_in_range(
-            &UTC.ymd(2021, 10, 1).and_hms(11, 0, 0),
+            &UTC.ymd(2021, 10, 1).and_hms(11, 0, 0).into(),
             &Some(start),
             &Some(end),
             inclusive
@@ -282,25 +282,25 @@ mod tests {
     #[test]
     fn in_range_inclusive_start() {
         let inclusive = true;
-        let start = UTC.ymd(2021, 10, 1).and_hms(8, 0, 0);
+        let start = UTC.ymd(2021, 10, 1).and_hms(8, 0, 0).into();
 
         // Just after
         assert!(is_in_range(
-            &UTC.ymd(2021, 10, 1).and_hms(9, 0, 0),
+            &UTC.ymd(2021, 10, 1).and_hms(9, 0, 0).into(),
             &Some(start),
             &None,
             inclusive
         ));
         // To small
         assert!(!is_in_range(
-            &UTC.ymd(2021, 10, 1).and_hms(7, 0, 0),
+            &UTC.ymd(2021, 10, 1).and_hms(7, 0, 0).into(),
             &Some(start),
             &None,
             inclusive
         ));
         // Bigger
         assert!(is_in_range(
-            &UTC.ymd(2021, 10, 2).and_hms(8, 0, 0),
+            &UTC.ymd(2021, 10, 2).and_hms(8, 0, 0).into(),
             &Some(start),
             &None,
             inclusive
@@ -312,25 +312,25 @@ mod tests {
     #[test]
     fn in_range_inclusive_end() {
         let inclusive = true;
-        let end = UTC.ymd(2021, 10, 1).and_hms(10, 0, 0);
+        let end = UTC.ymd(2021, 10, 1).and_hms(10, 0, 0).into();
 
         // Just before
         assert!(is_in_range(
-            &UTC.ymd(2021, 10, 1).and_hms(9, 0, 0),
+            &UTC.ymd(2021, 10, 1).and_hms(9, 0, 0).into(),
             &None,
             &Some(end),
             inclusive
         ));
         // Smaller
         assert!(is_in_range(
-            &UTC.ymd(2021, 9, 20).and_hms(10, 0, 0),
+            &UTC.ymd(2021, 9, 20).and_hms(10, 0, 0).into(),
             &None,
             &Some(end),
             inclusive
         ));
         // Bigger
         assert!(!is_in_range(
-            &UTC.ymd(2021, 10, 2).and_hms(8, 0, 0),
+            &UTC.ymd(2021, 10, 2).and_hms(8, 0, 0).into(),
             &None,
             &Some(end),
             inclusive
@@ -345,21 +345,21 @@ mod tests {
 
         // Some date
         assert!(is_in_range(
-            &UTC.ymd(2021, 10, 1).and_hms(9, 0, 0),
+            &UTC.ymd(2021, 10, 1).and_hms(9, 0, 0).into(),
             &None,
             &None,
             inclusive
         ));
         // Smaller
         assert!(is_in_range(
-            &UTC.ymd(2021, 9, 20).and_hms(10, 0, 0),
+            &UTC.ymd(2021, 9, 20).and_hms(10, 0, 0).into(),
             &None,
             &None,
             inclusive
         ));
         // Bigger
         assert!(is_in_range(
-            &UTC.ymd(2021, 10, 2).and_hms(8, 0, 0),
+            &UTC.ymd(2021, 10, 2).and_hms(8, 0, 0).into(),
             &None,
             &None,
             inclusive

--- a/rrule/src/iter/counter_date.rs
+++ b/rrule/src/iter/counter_date.rs
@@ -318,7 +318,7 @@ mod tests {
     use super::*;
 
     fn ymd_hms(year: i32, month: u32, day: u32, hour: u32, min: u32, sec: u32) -> DateTimeIter {
-        let dt = UTC.ymd(year, month, day).and_hms(hour, min, sec);
+        let dt = UTC.ymd(year, month, day).and_hms(hour, min, sec).into();
         DateTimeIter::from(&dt)
     }
 

--- a/rrule/src/iter/counter_date.rs
+++ b/rrule/src/iter/counter_date.rs
@@ -1,4 +1,4 @@
-use chrono::{Datelike, TimeZone, Timelike, Utc, Weekday};
+use chrono::{Datelike, TimeZone, Utc, Weekday};
 
 use crate::{core::DateTime, Frequency, RRule, RRuleError};
 

--- a/rrule/src/iter/mod.rs
+++ b/rrule/src/iter/mod.rs
@@ -18,6 +18,7 @@ use iterinfo::IterInfo;
 use pos_list::build_pos_list;
 pub(crate) use rrule_iter::RRuleIter;
 pub use rruleset_iter::RRuleSetIter;
+pub(crate) use utils::add_time_to_date;
 
 /// Prevent loops when searching for the next event in the iterator.
 /// If after X amount of iterations it still has not found an event

--- a/rrule/src/iter/pos_list.rs
+++ b/rrule/src/iter/pos_list.rs
@@ -1,4 +1,4 @@
-use super::utils::{add_time_to_date, from_ordinal, pymod};
+use super::utils::{from_ordinal, pymod};
 use crate::{
     core::{DateTime, RRuleTimeZone},
     RRuleError,

--- a/rrule/src/iter/pos_list.rs
+++ b/rrule/src/iter/pos_list.rs
@@ -1,14 +1,16 @@
 use super::utils::{add_time_to_date, from_ordinal, pymod};
-use crate::{core::DateTime, RRuleError};
+use crate::{
+    core::{DateTime, RRuleTimeZone},
+    RRuleError,
+};
 use chrono::NaiveTime;
-use chrono_tz::Tz;
 
 pub(crate) fn build_pos_list(
     by_set_pos: &[i32],
     dayset: &[usize],
     timeset: &[NaiveTime],
     year_ordinal: i64,
-    tz: Tz,
+    tz: RRuleTimeZone,
 ) -> Result<Vec<DateTime>, RRuleError> {
     let mut pos_list = vec![];
     if timeset.is_empty() {
@@ -49,12 +51,12 @@ pub(crate) fn build_pos_list(
             .expect("dayset is controlled by us and all elements are within range of i64");
 
         // Get ordinal which is UTC and apply timezone
-        let date = from_ordinal(year_ordinal + day).date().with_timezone(&tz);
+        let date = from_ordinal(year_ordinal + day);
         // Create new Date + Time combination
         // Use Date and Timezone from `date`
         // Use Time from `timeset`.
         let time = timeset[time_pos];
-        let res = match add_time_to_date(date, time) {
+        let res = match tz.datetime(date.year(), date.month(), date.day(), time) {
             Some(date) => date,
             None => continue,
         };

--- a/rrule/src/iter/rrule_iter.rs
+++ b/rrule/src/iter/rrule_iter.rs
@@ -1,11 +1,9 @@
 use super::counter_date::DateTimeIter;
-use super::utils::add_time_to_date;
 use super::{build_pos_list, utils::from_ordinal, IterInfo, MAX_ITER_LOOP};
 use crate::core::{get_hour, get_minute, get_second};
 use crate::validator::check_limits;
 use crate::{core::DateTime, Frequency, RRule, RRuleError, WithError};
-use chrono::Datelike;
-use chrono::{NaiveTime, TimeZone};
+use chrono::NaiveTime;
 use std::collections::VecDeque;
 
 #[derive(Debug, Clone)]

--- a/rrule/src/iter/rrule_iter.rs
+++ b/rrule/src/iter/rrule_iter.rs
@@ -147,14 +147,14 @@ impl<'a> RRuleIter<'a> {
                     // Ordinal conversion uses UTC: if we apply local-TZ here, then
                     // just below we'll end up double-applying.
                     let date = from_ordinal(year_ordinal + current_day);
-                    // We apply the local-TZ here,
-                    let date = self
-                        .dt_start
-                        .timezone()
-                        .ymd(date.year(), date.month(), date.day());
 
                     for time in &self.timeset {
-                        let dt = match add_time_to_date(date, *time) {
+                        let dt = match self.dt_start.timezone().datetime(
+                            date.year(),
+                            date.month(),
+                            date.day(),
+                            *time,
+                        ) {
                             Some(dt) => dt,
                             None => continue,
                         };

--- a/rrule/src/iter/utils.rs
+++ b/rrule/src/iter/utils.rs
@@ -1,8 +1,8 @@
 use std::ops;
 
 use crate::core::{duration_from_midnight, DateTime};
-use chrono::{Date, NaiveTime, TimeZone, Utc};
-use chrono_tz::{Tz, UTC};
+use chrono::{NaiveTime, TimeZone, Utc};
+use chrono_tz::UTC;
 
 const DAY_SECS: i64 = 24 * 60 * 60;
 

--- a/rrule/src/lib.rs
+++ b/rrule/src/lib.rs
@@ -89,7 +89,7 @@ mod parser;
 mod tests;
 mod validator;
 
-pub use crate::core::{Frequency, NWeekday, RRule, RRuleSet};
+pub use crate::core::{DateTime, Frequency, NWeekday, RRule, RRuleSet};
 pub use crate::core::{Unvalidated, Validated};
 pub use chrono::Weekday;
 pub use error::{RRuleError, WithError};

--- a/rrule/src/parser/content_line/date_content_line.rs
+++ b/rrule/src/parser/content_line/date_content_line.rs
@@ -76,7 +76,7 @@ mod tests {
                     parameters: None,
                     value: "19970714T123000Z",
                 },
-                vec![UTC.ymd(1997, 7, 14).and_hms(12, 30, 0)],
+                vec![UTC.ymd(1997, 7, 14).and_hms(12, 30, 0).into()],
             ),
             (
                 ContentLineCaptures {
@@ -85,10 +85,10 @@ mod tests {
                     value: "19970101,19970120,19970217,19970421",
                 },
                 vec![
-                    UTC.ymd(1997, 1, 1).and_hms(0, 0, 0),
-                    UTC.ymd(1997, 1, 20).and_hms(0, 0, 0),
-                    UTC.ymd(1997, 2, 17).and_hms(0, 0, 0),
-                    UTC.ymd(1997, 4, 21).and_hms(0, 0, 0),
+                    UTC.ymd(1997, 1, 1).and_hms(0, 0, 0).into(),
+                    UTC.ymd(1997, 1, 20).and_hms(0, 0, 0).into(),
+                    UTC.ymd(1997, 2, 17).and_hms(0, 0, 0).into(),
+                    UTC.ymd(1997, 4, 21).and_hms(0, 0, 0).into(),
                 ],
             ),
         ];

--- a/rrule/src/parser/content_line/rule_content_line.rs
+++ b/rrule/src/parser/content_line/rule_content_line.rs
@@ -394,10 +394,7 @@ mod tests {
         props.insert(RRuleProperty::Freq, "DAILY".into());
         let until_str = "19970904";
         let until_local = NaiveDate::from_ymd(1997, 9, 4).and_hms(0, 0, 0);
-        let until_local = chrono::Local
-            .from_local_datetime(&until_local)
-            .unwrap()
-            .with_timezone(&chrono_tz::UTC);
+        let until_local = chrono::Local.from_local_datetime(&until_local).unwrap();
         props.insert(RRuleProperty::Until, until_str.into());
 
         let start_date = ContentLineCaptures::new("DTSTART:19970902").unwrap();
@@ -413,10 +410,7 @@ mod tests {
         props.insert(RRuleProperty::Freq, "DAILY".into());
         let until_str = "19970904T090000";
         let until_local = NaiveDate::from_ymd(1997, 9, 4).and_hms(9, 0, 0);
-        let until_local = chrono::Local
-            .from_local_datetime(&until_local)
-            .unwrap()
-            .with_timezone(&chrono_tz::UTC);
+        let until_local = chrono::Local.from_local_datetime(&until_local).unwrap();
         props.insert(RRuleProperty::Until, until_str.into());
 
         let start_date = ContentLineCaptures::new("DTSTART:19970902T090000").unwrap();

--- a/rrule/src/parser/content_line/rule_content_line.rs
+++ b/rrule/src/parser/content_line/rule_content_line.rs
@@ -300,7 +300,7 @@ mod tests {
         ];
 
         let start_date = StartDateContentLine {
-            datetime: UTC.ymd(2000, 1, 1).and_hms(0, 0, 0),
+            datetime: UTC.ymd(2000, 1, 1).and_hms(0, 0, 0).into(),
             timezone: None,
             value: "DATE-TIME",
         };
@@ -322,7 +322,7 @@ mod tests {
             ParseError::PropertyParametersNotSupported("TZID=Europe/London".into()),
         )];
         let start_date = StartDateContentLine {
-            datetime: UTC.ymd(2000, 1, 1).and_hms(0, 0, 0),
+            datetime: UTC.ymd(2000, 1, 1).and_hms(0, 0, 0).into(),
             timezone: None,
             value: "DATE-TIME",
         };
@@ -338,7 +338,7 @@ mod tests {
         let mut props = HashMap::new();
         props.insert(RRuleProperty::Freq, "DAIL".into());
         let start_date = StartDateContentLine {
-            datetime: UTC.ymd(2000, 1, 1).and_hms(0, 0, 0),
+            datetime: UTC.ymd(2000, 1, 1).and_hms(0, 0, 0).into(),
             timezone: None,
             value: "DATE-TIME",
         };
@@ -355,7 +355,7 @@ mod tests {
         props.insert(RRuleProperty::Freq, "DAILY".into());
         props.insert(RRuleProperty::ByHour, "24".into());
         let start_date = StartDateContentLine {
-            datetime: UTC.ymd(2000, 1, 1).and_hms(0, 0, 0),
+            datetime: UTC.ymd(2000, 1, 1).and_hms(0, 0, 0).into(),
             timezone: None,
             value: "DATE-TIME",
         };
@@ -373,7 +373,7 @@ mod tests {
         props.insert(RRuleProperty::Freq, "DAILY".into());
         props.insert(RRuleProperty::ByMinute, "60".into());
         let start_date = StartDateContentLine {
-            datetime: UTC.ymd(2000, 1, 1).and_hms(0, 0, 0),
+            datetime: UTC.ymd(2000, 1, 1).and_hms(0, 0, 0).into(),
             timezone: None,
             value: "DATE-TIME",
         };
@@ -404,7 +404,7 @@ mod tests {
         let start_date = StartDateContentLine::try_from(&start_date).unwrap();
 
         let rrule = props_to_rrule(&props, &start_date).unwrap();
-        assert_eq!(rrule.until, Some(until_local));
+        assert_eq!(rrule.until, Some(until_local.into()));
     }
 
     #[test]
@@ -423,7 +423,7 @@ mod tests {
         let start_date = StartDateContentLine::try_from(&start_date).unwrap();
 
         let rrule = props_to_rrule(&props, &start_date).unwrap();
-        assert_eq!(rrule.until, Some(until_local));
+        assert_eq!(rrule.until, Some(until_local.into()));
     }
 
     #[test]
@@ -444,7 +444,7 @@ mod tests {
             let start_date = StartDateContentLine::try_from(&start_date).unwrap();
 
             let rrule = props_to_rrule(&props, &start_date).unwrap();
-            assert_eq!(rrule.until, Some(until_local));
+            assert_eq!(rrule.until, Some(until_local.into()));
         }
     }
 
@@ -468,7 +468,7 @@ mod tests {
             let start_date = StartDateContentLine::try_from(&start_date).unwrap();
 
             let rrule = props_to_rrule(&props, &start_date).unwrap();
-            assert_eq!(rrule.until, Some(until_local));
+            assert_eq!(rrule.until, Some(until_local.into()));
         }
     }
 

--- a/rrule/src/parser/content_line/rule_content_line.rs
+++ b/rrule/src/parser/content_line/rule_content_line.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashMap, marker::PhantomData, str::FromStr};
 
 use chrono::Weekday;
-use chrono_tz::UTC;
 
 use crate::{
     core::DateTime,
@@ -15,9 +14,7 @@ use crate::{
     Frequency, RRule, Unvalidated,
 };
 
-use super::{
-    content_line_parts::ContentLineCaptures, start_date_content_line::StartDateContentLine,
-};
+use super::content_line_parts::ContentLineCaptures;
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 pub enum RRuleProperty {
@@ -66,12 +63,10 @@ impl FromStr for RRuleProperty {
     }
 }
 
-impl<'a> TryFrom<(ContentLineCaptures<'a>, &StartDateContentLine)> for RRule<Unvalidated> {
+impl<'a> TryFrom<ContentLineCaptures<'a>> for RRule<Unvalidated> {
     type Error = ParseError;
 
-    fn try_from(
-        (value, dtstart): (ContentLineCaptures, &StartDateContentLine),
-    ) -> Result<Self, Self::Error> {
+    fn try_from(value: ContentLineCaptures) -> Result<Self, Self::Error> {
         if let Some(parameters) = value.parameters {
             if !parameters.is_empty() {
                 return Err(ParseError::PropertyParametersNotSupported(
@@ -82,7 +77,7 @@ impl<'a> TryFrom<(ContentLineCaptures<'a>, &StartDateContentLine)> for RRule<Unv
 
         let properties: HashMap<RRuleProperty, String> = parse_parameters(value.value)?;
 
-        props_to_rrule(&properties, dtstart)
+        props_to_rrule(&properties)
     }
 }
 
@@ -90,7 +85,6 @@ impl<'a> TryFrom<(ContentLineCaptures<'a>, &StartDateContentLine)> for RRule<Unv
 #[allow(clippy::too_many_lines)]
 fn props_to_rrule(
     props: &HashMap<RRuleProperty, String>,
-    dtstart: &StartDateContentLine,
 ) -> Result<RRule<Unvalidated>, ParseError> {
     let freq = props
         .get(&RRuleProperty::Freq)
@@ -116,7 +110,7 @@ fn props_to_rrule(
         .transpose()?;
     let until = props
         .get(&RRuleProperty::Until)
-        .map(|until| parse_until(until, dtstart))
+        .map(|until| parse_until(until))
         .transpose()?;
     let week_start = props
         .get(&RRuleProperty::Wkst)
@@ -229,30 +223,13 @@ fn props_to_rrule(
     })
 }
 
-/// Parses UNTIL string to a `DateTime` based on values parsed from the start date.
-fn parse_until(until: &str, dtstart: &StartDateContentLine) -> Result<DateTime, ParseError> {
-    let until_value = if until.len() > 8 { "DATE-TIME" } else { "DATE" };
-    if until_value != dtstart.value {
-        return Err(ParseError::DtStartUntilMismatchValue);
-    }
-
-    let timezone = if dtstart.timezone.is_none() {
-        if until_value == "DATE-TIME" && until.to_uppercase().ends_with('Z') {
-            return Err(ParseError::DtStartUntilMismatchTimezone);
-        }
-
-        None
-    } else {
-        Some(UTC)
-    };
-
-    datestring_to_date(until, timezone, "UNTIL")
+fn parse_until(until: &str) -> Result<DateTime, ParseError> {
+    datestring_to_date(until, None, "UNTIL")
 }
 
 #[cfg(test)]
 mod tests {
-    use chrono::{DateTime, NaiveDate, TimeZone};
-    use chrono_tz::Tz;
+    use chrono::{NaiveDate, TimeZone};
 
     use crate::parser::content_line::{ContentLineCaptures, PropertyName};
 
@@ -299,14 +276,8 @@ mod tests {
             ),
         ];
 
-        let start_date = StartDateContentLine {
-            datetime: UTC.ymd(2000, 1, 1).and_hms(0, 0, 0).into(),
-            timezone: None,
-            value: "DATE-TIME",
-        };
-
         for (input, expected_output) in tests {
-            let output = RRule::try_from((input, &start_date));
+            let output = RRule::try_from(input);
             assert_eq!(output, Ok(expected_output));
         }
     }
@@ -321,14 +292,9 @@ mod tests {
             },
             ParseError::PropertyParametersNotSupported("TZID=Europe/London".into()),
         )];
-        let start_date = StartDateContentLine {
-            datetime: UTC.ymd(2000, 1, 1).and_hms(0, 0, 0).into(),
-            timezone: None,
-            value: "DATE-TIME",
-        };
 
         for (input, expected_output) in tests {
-            let output = RRule::try_from((input, &start_date));
+            let output = RRule::try_from(input);
             assert_eq!(output, Err(expected_output));
         }
     }
@@ -337,12 +303,7 @@ mod tests {
     fn rejects_invalid_freq() {
         let mut props = HashMap::new();
         props.insert(RRuleProperty::Freq, "DAIL".into());
-        let start_date = StartDateContentLine {
-            datetime: UTC.ymd(2000, 1, 1).and_hms(0, 0, 0).into(),
-            timezone: None,
-            value: "DATE-TIME",
-        };
-        let res = props_to_rrule(&props, &start_date);
+        let res = props_to_rrule(&props);
         assert_eq!(
             res.unwrap_err(),
             ParseError::InvalidFrequency("DAIL".into())
@@ -354,16 +315,11 @@ mod tests {
         let mut props = HashMap::new();
         props.insert(RRuleProperty::Freq, "DAILY".into());
         props.insert(RRuleProperty::ByHour, "24".into());
-        let start_date = StartDateContentLine {
-            datetime: UTC.ymd(2000, 1, 1).and_hms(0, 0, 0).into(),
-            timezone: None,
-            value: "DATE-TIME",
-        };
-        let res = props_to_rrule(&props, &start_date);
+        let res = props_to_rrule(&props);
         assert_eq!(res.unwrap_err(), ParseError::InvalidByHour("24".into()));
 
         props.insert(RRuleProperty::ByHour, "5,6,25".into());
-        let res = props_to_rrule(&props, &start_date);
+        let res = props_to_rrule(&props);
         assert_eq!(res.unwrap_err(), ParseError::InvalidByHour("5,6,25".into()));
     }
 
@@ -372,16 +328,11 @@ mod tests {
         let mut props = HashMap::new();
         props.insert(RRuleProperty::Freq, "DAILY".into());
         props.insert(RRuleProperty::ByMinute, "60".into());
-        let start_date = StartDateContentLine {
-            datetime: UTC.ymd(2000, 1, 1).and_hms(0, 0, 0).into(),
-            timezone: None,
-            value: "DATE-TIME",
-        };
-        let res = props_to_rrule(&props, &start_date);
+        let res = props_to_rrule(&props);
         assert_eq!(res.unwrap_err(), ParseError::InvalidByMinute("60".into()));
 
         props.insert(RRuleProperty::ByMinute, "4,5,64".into());
-        let res = props_to_rrule(&props, &start_date);
+        let res = props_to_rrule(&props);
         assert_eq!(
             res.unwrap_err(),
             ParseError::InvalidByMinute("4,5,64".into())
@@ -397,10 +348,7 @@ mod tests {
         let until_local = chrono::Local.from_local_datetime(&until_local).unwrap();
         props.insert(RRuleProperty::Until, until_str.into());
 
-        let start_date = ContentLineCaptures::new("DTSTART:19970902").unwrap();
-        let start_date = StartDateContentLine::try_from(&start_date).unwrap();
-
-        let rrule = props_to_rrule(&props, &start_date).unwrap();
+        let rrule = props_to_rrule(&props).unwrap();
         assert_eq!(rrule.until, Some(until_local.into()));
     }
 
@@ -413,84 +361,7 @@ mod tests {
         let until_local = chrono::Local.from_local_datetime(&until_local).unwrap();
         props.insert(RRuleProperty::Until, until_str.into());
 
-        let start_date = ContentLineCaptures::new("DTSTART:19970902T090000").unwrap();
-        let start_date = StartDateContentLine::try_from(&start_date).unwrap();
-
-        let rrule = props_to_rrule(&props, &start_date).unwrap();
+        let rrule = props_to_rrule(&props).unwrap();
         assert_eq!(rrule.until, Some(until_local.into()));
-    }
-
-    #[test]
-    fn until_is_utc_when_start_date_has_timezone() {
-        let mut props = HashMap::new();
-        props.insert(RRuleProperty::Freq, "DAILY".into());
-        let until_str = "20000902";
-        let until_local: DateTime<Tz> = UTC.ymd(2000, 9, 2).and_hms(0, 0, 0);
-        props.insert(RRuleProperty::Until, until_str.into());
-
-        let start_dates = [
-            "DTSTART;TZID=UTC:19970902",
-            "DTSTART;TZID=Europe/London:19970902",
-        ];
-
-        for start_date in start_dates {
-            let start_date = ContentLineCaptures::new(start_date).unwrap();
-            let start_date = StartDateContentLine::try_from(&start_date).unwrap();
-
-            let rrule = props_to_rrule(&props, &start_date).unwrap();
-            assert_eq!(rrule.until, Some(until_local.into()));
-        }
-    }
-
-    #[test]
-    fn until_is_utc_when_start_datetime_has_timezone() {
-        let mut props = HashMap::new();
-        props.insert(RRuleProperty::Freq, "DAILY".into());
-        let until_str = "19970904T090000";
-        let until_local: DateTime<Tz> = UTC.ymd(1997, 9, 4).and_hms(9, 0, 0);
-        props.insert(RRuleProperty::Until, until_str.into());
-
-        let start_dates = [
-            "DTSTART:19970902T090000Z",
-            "DTSTART;TZID=UTC:19970902T090000",
-            "DTSTART;TZID=UTC:19970902T090000Z",
-            "DTSTART;TZID=Europe/London:19970902T090000",
-        ];
-
-        for start_date in start_dates {
-            let start_date = ContentLineCaptures::new(start_date).unwrap();
-            let start_date = StartDateContentLine::try_from(&start_date).unwrap();
-
-            let rrule = props_to_rrule(&props, &start_date).unwrap();
-            assert_eq!(rrule.until, Some(until_local.into()));
-        }
-    }
-
-    #[test]
-    fn reject_until_with_zulu_if_start_date_is_local() {
-        let mut props = HashMap::new();
-        props.insert(RRuleProperty::Freq, "DAILY".into());
-        let until_str = "19970902T090000Z";
-        props.insert(RRuleProperty::Until, until_str.into());
-
-        let start_date = ContentLineCaptures::new("DTSTART:19970902T090000").unwrap();
-        let start_date = StartDateContentLine::try_from(&start_date).unwrap();
-
-        let res = props_to_rrule(&props, &start_date);
-        assert_eq!(res, Err(ParseError::DtStartUntilMismatchTimezone));
-    }
-
-    #[test]
-    fn reject_until_with_value_paramter_different_from_start_date() {
-        let mut props = HashMap::new();
-        props.insert(RRuleProperty::Freq, "DAILY".into());
-        let until_str = "19970902T090000";
-        props.insert(RRuleProperty::Until, until_str.into());
-
-        let start_date = ContentLineCaptures::new("DTSTART:19970902").unwrap();
-        let start_date = StartDateContentLine::try_from(&start_date).unwrap();
-
-        let res = props_to_rrule(&props, &start_date);
-        assert_eq!(res, Err(ParseError::DtStartUntilMismatchValue));
     }
 }

--- a/rrule/src/parser/content_line/start_date_content_line.rs
+++ b/rrule/src/parser/content_line/start_date_content_line.rs
@@ -85,7 +85,7 @@ mod tests {
                     value: "19970714T123000Z",
                 },
                 StartDateContentLine {
-                    datetime: UTC.ymd(1997, 7, 14).and_hms(12, 30, 0),
+                    datetime: UTC.ymd(1997, 7, 14).and_hms(12, 30, 0).into(),
                     timezone: Some(UTC),
                     value: "DATE-TIME",
                 },
@@ -97,7 +97,7 @@ mod tests {
                     value: "19970101",
                 },
                 StartDateContentLine {
-                    datetime: UTC.ymd(1997, 1, 1).and_hms(0, 0, 0),
+                    datetime: UTC.ymd(1997, 1, 1).and_hms(0, 0, 0).into(),
                     timezone: Some(UTC),
                     value: "DATE",
                 },
@@ -109,7 +109,7 @@ mod tests {
                     value: "19970101",
                 },
                 StartDateContentLine {
-                    datetime: UTC.ymd(1997, 1, 1).and_hms(0, 0, 0),
+                    datetime: UTC.ymd(1997, 1, 1).and_hms(0, 0, 0).into(),
                     timezone: Some(UTC),
                     value: "DATE",
                 },

--- a/rrule/src/parser/mod.rs
+++ b/rrule/src/parser/mod.rs
@@ -8,13 +8,13 @@ mod utils;
 
 use std::str::FromStr;
 
-pub(crate) use content_line::ContentLine;
+pub(crate) use content_line::{ContentLine, ContentLineCaptures};
 pub(crate) use datetime::str_to_weekday;
 pub use error::ParseError;
 
 use crate::RRule;
 
-use self::content_line::{ContentLineCaptures, PropertyName, StartDateContentLine};
+use self::content_line::{PropertyName, StartDateContentLine};
 
 /// Grammar represents a well formatted rrule input.
 #[derive(Debug, PartialEq)]

--- a/rrule/src/parser/mod.rs
+++ b/rrule/src/parser/mod.rs
@@ -89,7 +89,7 @@ mod test {
         let tests = [
 (
     "DTSTART:19970902T090000Z\nRRULE:FREQ=YEARLY;COUNT=3\n", Grammar {
-    start: StartDateContentLine { datetime: UTC.ymd(1997, 9, 2).and_hms(9, 0, 0), timezone: Some(UTC), value: "DATE-TIME" },
+    start: StartDateContentLine { datetime: UTC.ymd(1997, 9, 2).and_hms(9, 0, 0).into(), timezone: Some(UTC), value: "DATE-TIME" },
     content_lines: vec![
         ContentLine::RRule(RRule {
             freq: Frequency::Yearly,
@@ -100,19 +100,19 @@ mod test {
 }
 ),
 ("DTSTART:20120201T093000Z\nRRULE:FREQ=WEEKLY;INTERVAL=5;UNTIL=20130130T230000Z;BYDAY=MO,FR", Grammar {
-    start: StartDateContentLine { datetime: UTC.ymd(2012, 2, 1).and_hms(9, 30, 0), timezone: Some(UTC), value: "DATE-TIME" },
+    start: StartDateContentLine { datetime: UTC.ymd(2012, 2, 1).and_hms(9, 30, 0).into(), timezone: Some(UTC), value: "DATE-TIME" },
     content_lines: vec![
         ContentLine::RRule(RRule {
             freq: Frequency::Weekly,
             interval: 5,
-            until: Some(UTC.ymd(2013, 1, 30).and_hms(23, 0, 0)),
+            until: Some(UTC.ymd(2013, 1, 30).and_hms(23, 0, 0).into()),
             by_weekday: vec![NWeekday::Every(Weekday::Mon), NWeekday::Every(Weekday::Fri)],
             ..Default::default()
         })
     ]
 }),
 ("DTSTART:20120201T120000Z\nRRULE:FREQ=DAILY;COUNT=5\nEXDATE;TZID=Europe/Berlin:20120202T130000,20120203T130000", Grammar {
-    start: StartDateContentLine { datetime: UTC.ymd(2012, 2, 1).and_hms(12, 0, 0), timezone: Some(UTC), value: "DATE-TIME" },
+    start: StartDateContentLine { datetime: UTC.ymd(2012, 2, 1).and_hms(12, 0, 0).into(), timezone: Some(UTC), value: "DATE-TIME" },
     content_lines: vec![
         ContentLine::RRule(RRule {
             freq: Frequency::Daily,
@@ -120,13 +120,13 @@ mod test {
             ..Default::default()
         }),
         ContentLine::ExDate(vec![
-            Europe::Berlin.ymd(2012, 2, 2).and_hms(13, 0, 0),
-            Europe::Berlin.ymd(2012, 2, 3).and_hms(13, 0, 0),
+            Europe::Berlin.ymd(2012, 2, 2).and_hms(13, 0, 0).into(),
+            Europe::Berlin.ymd(2012, 2, 3).and_hms(13, 0, 0).into(),
         ])
     ]
 }),
 ("DTSTART:20120201T120000Z\nRRULE:FREQ=DAILY;COUNT=5\nEXDATE;TZID=Europe/Berlin:20120202T130000,20120203T130000\nEXRULE:FREQ=WEEKLY;COUNT=10", Grammar {
-    start: StartDateContentLine { datetime: UTC.ymd(2012, 2, 1).and_hms(12, 0, 0), timezone: Some(UTC), value: "DATE-TIME" },
+    start: StartDateContentLine { datetime: UTC.ymd(2012, 2, 1).and_hms(12, 0, 0).into(), timezone: Some(UTC), value: "DATE-TIME" },
     content_lines: vec![
         ContentLine::RRule(RRule {
             freq: Frequency::Daily,
@@ -134,8 +134,8 @@ mod test {
             ..Default::default()
         }),
         ContentLine::ExDate(vec![
-            Europe::Berlin.ymd(2012, 2, 2).and_hms(13, 0, 0),
-            Europe::Berlin.ymd(2012, 2, 3).and_hms(13, 0, 0),
+            Europe::Berlin.ymd(2012, 2, 2).and_hms(13, 0, 0).into(),
+            Europe::Berlin.ymd(2012, 2, 3).and_hms(13, 0, 0).into(),
         ]),
         ContentLine::ExRule(RRule {
             freq: Frequency::Weekly,

--- a/rrule/src/parser/mod.rs
+++ b/rrule/src/parser/mod.rs
@@ -44,11 +44,11 @@ impl FromStr for Grammar {
         for parts in content_lines_parts {
             let line = match parts.property_name {
                 PropertyName::RRule => {
-                    let rrule = RRule::try_from((parts, &start))?;
+                    let rrule = RRule::try_from(parts)?;
                     ContentLine::RRule(rrule)
                 }
                 PropertyName::ExRule => {
-                    let rrule = RRule::try_from((parts, &start))?;
+                    let rrule = RRule::try_from(parts)?;
                     ContentLine::ExRule(rrule)
                 }
                 PropertyName::RDate => ContentLine::RDate(TryFrom::try_from(parts)?),

--- a/rrule/src/tests/common.rs
+++ b/rrule/src/tests/common.rs
@@ -1,27 +1,22 @@
 #![cfg(test)]
 #![allow(dead_code)]
 
-use crate::{RRule, RRuleError, RRuleSet, Unvalidated};
-use chrono::{DateTime, TimeZone};
+use crate::{core::DateTime, RRule, RRuleError, RRuleSet, Unvalidated};
+use chrono::TimeZone;
 use chrono_tz::{Tz, UTC};
 use std::fmt::Debug;
 
-pub fn ymd_hms(
-    year: i32,
-    month: u32,
-    day: u32,
-    hour: u32,
-    minute: u32,
-    second: u32,
-) -> DateTime<Tz> {
-    UTC.ymd(year, month, day).and_hms(hour, minute, second)
+pub fn ymd_hms(year: i32, month: u32, day: u32, hour: u32, minute: u32, second: u32) -> DateTime {
+    UTC.ymd(year, month, day)
+        .and_hms(hour, minute, second)
+        .into()
 }
 
 pub fn test_recurring_rrule(
     rrule: RRule<Unvalidated>,
     limited: bool,
-    dt_start: DateTime<Tz>,
-    expected_dates: &[DateTime<Tz>],
+    dt_start: DateTime,
+    expected_dates: &[DateTime],
 ) {
     let rrule_set = rrule
         .build(dt_start)
@@ -51,7 +46,7 @@ pub fn test_recurring_rrule(
 }
 
 #[allow(clippy::needless_pass_by_value)]
-pub fn test_recurring_rrule_set(rrule_set: RRuleSet, expected_dates: &[DateTime<Tz>]) {
+pub fn test_recurring_rrule_set(rrule_set: RRuleSet, expected_dates: &[DateTime]) {
     let res = rrule_set.all(u16::MAX).unwrap();
 
     println!("Actual: {:?}", res);
@@ -68,8 +63,8 @@ pub fn test_recurring_rrule_set(rrule_set: RRuleSet, expected_dates: &[DateTime<
 }
 
 /// Print and compare 2 lists of dates and panic it they are not the same.
-pub fn check_occurrences<S: AsRef<str> + Debug>(occurrences: &[DateTime<Tz>], expected: &[S]) {
-    let formatter = |dt: &DateTime<Tz>| -> String { format!("    \"{}\",\n", dt.to_rfc3339()) };
+pub fn check_occurrences<S: AsRef<str> + Debug>(occurrences: &[DateTime], expected: &[S]) {
+    let formatter = |dt: &DateTime| -> String { format!("    \"{}\",\n", dt.to_rfc3339()) };
     println!(
         "Given: [\n{}]\nExpected: {:#?}",
         occurrences.iter().map(formatter).collect::<String>(),

--- a/rrule/src/tests/common.rs
+++ b/rrule/src/tests/common.rs
@@ -3,7 +3,7 @@
 
 use crate::{core::DateTime, RRule, RRuleError, RRuleSet, Unvalidated};
 use chrono::TimeZone;
-use chrono_tz::{Tz, UTC};
+use chrono_tz::UTC;
 use std::fmt::Debug;
 
 pub fn ymd_hms(year: i32, month: u32, day: u32, hour: u32, minute: u32, second: u32) -> DateTime {

--- a/rrule/src/tests/rrule.rs
+++ b/rrule/src/tests/rrule.rs
@@ -1,6 +1,6 @@
 use crate::tests::common::{test_recurring_rrule, ymd_hms};
 use crate::{Frequency, NWeekday, RRule, RRuleSet, Weekday};
-use chrono::{Datelike, TimeZone};
+use chrono::TimeZone;
 
 #[test]
 fn yearly() {

--- a/rrule/src/validator/check_limits.rs
+++ b/rrule/src/validator/check_limits.rs
@@ -39,7 +39,6 @@ pub(crate) static FREQ_SECONDLY_INTERVAL_MAX: u16 = 50_000;
 /// iterator.
 pub(crate) fn check_limits(rrule: &RRule, dt_start: &DateTime) -> Result<(), ValidationError> {
     use crate::{validator::YEAR_RANGE, Frequency};
-    use chrono::Datelike;
 
     // Interval:
     // - Value should not be to big

--- a/rrule/src/validator/error.rs
+++ b/rrule/src/validator/error.rs
@@ -45,4 +45,12 @@ pub enum ValidationError {
     #[cfg(feature = "by-easter")]
     #[error("`BYEASTER` can only be used when `BYHOUR`, `BYMINUTE` and `BYSECOND` are set.")]
     InvalidByRuleWithByEaster,
+    #[error(
+        "The value of `DTSTART` was specified in {dt_start_tz} timezone, but `UNTIL` was specified in timezone {until_tz}. Allowed timezones for `UNTIL` with the given start date timezone are: `{expected:?}`"
+    )]
+    DtStartUntilMismatchTimezone {
+        dt_start_tz: String,
+        until_tz: String,
+        expected: Vec<String>,
+    },
 }

--- a/rrule/src/validator/validate_rrule.rs
+++ b/rrule/src/validator/validate_rrule.rs
@@ -338,7 +338,7 @@ mod tests {
             by_set_pos: vec![-1],
             ..Default::default()
         };
-        let dt_start = UTC.ymd(1970, 1, 1).and_hms(0, 0, 0);
+        let dt_start = UTC.ymd(1970, 1, 1).and_hms(0, 0, 0).into();
         let res = validate_rrule_forced(&rrule, &dt_start);
         assert!(res.is_err());
         let err = res.unwrap_err();
@@ -385,7 +385,7 @@ mod tests {
             ),
         ];
         for (field, rrule) in tests {
-            let res = validate_rrule_forced(&rrule, &UTC.ymd(1970, 1, 1).and_hms(0, 0, 0));
+            let res = validate_rrule_forced(&rrule, &UTC.ymd(1970, 1, 1).and_hms(0, 0, 0).into());
             assert!(res.is_err());
             let err = res.unwrap_err();
             assert_eq!(
@@ -423,7 +423,7 @@ mod tests {
             ),
         ];
         for (field, rrule, value, start_idx, end_idx) in tests {
-            let res = validate_rrule_forced(&rrule, &UTC.ymd(1970, 1, 1).and_hms(0, 0, 0));
+            let res = validate_rrule_forced(&rrule, &UTC.ymd(1970, 1, 1).and_hms(0, 0, 0).into());
             assert!(res.is_err());
             let err = res.unwrap_err();
             assert_eq!(
@@ -465,7 +465,7 @@ mod tests {
             ),
         ];
         for (field, rrule, value, start_idx, end_idx) in tests {
-            let res = validate_rrule_forced(&rrule, &UTC.ymd(1970, 1, 1).and_hms(0, 0, 0));
+            let res = validate_rrule_forced(&rrule, &UTC.ymd(1970, 1, 1).and_hms(0, 0, 0).into());
             assert!(res.is_err());
             let err = res.unwrap_err();
             assert_eq!(
@@ -518,7 +518,7 @@ mod tests {
             ),
         ];
         for (field, rrule) in tests {
-            let res = validate_rrule_forced(&rrule, &UTC.ymd(1970, 1, 1).and_hms(0, 0, 0));
+            let res = validate_rrule_forced(&rrule, &UTC.ymd(1970, 1, 1).and_hms(0, 0, 0).into());
             assert!(res.is_err());
             let err = res.unwrap_err();
             assert_eq!(
@@ -534,10 +534,10 @@ mod tests {
     #[test]
     fn rejects_start_date_after_until() {
         let rrule = RRule {
-            until: Some(UTC.ymd_opt(2020, 1, 1).and_hms_opt(0, 0, 0).unwrap()),
+            until: Some(UTC.ymd_opt(2020, 1, 1).and_hms_opt(0, 0, 0).unwrap().into()),
             ..Default::default()
         };
-        let dt_start = UTC.ymd_opt(2020, 1, 2).and_hms_opt(0, 0, 0).unwrap();
+        let dt_start = UTC.ymd_opt(2020, 1, 2).and_hms_opt(0, 0, 0).unwrap().into();
         let res = validate_rrule_forced(&rrule, &dt_start);
         assert!(res.is_err());
         let err = res.unwrap_err();

--- a/rrule/src/validator/validate_rrule.rs
+++ b/rrule/src/validator/validate_rrule.rs
@@ -1,6 +1,6 @@
 use std::ops::RangeInclusive;
 
-use crate::core::DateTime;
+use crate::core::{DateTime, RRuleTimeZone};
 use crate::{Frequency, NWeekday, RRule, Unvalidated};
 
 use super::ValidationError;
@@ -45,13 +45,42 @@ pub(crate) fn validate_rrule_forced(
 }
 
 // Until:
+// - Timezones are correctly synced as specified in the RFC
 // - Value should be later than `dt_start`.
 fn validate_until(rrule: &RRule<Unvalidated>, dt_start: &DateTime) -> Result<(), ValidationError> {
     match rrule.until {
-        Some(until) if until < *dt_start => Err(ValidationError::UntilBeforeStart {
-            until: until.to_rfc3339(),
-            dt_start: dt_start.to_rfc3339(),
-        }),
+        Some(until) => {
+            match dt_start.timezone() {
+                RRuleTimeZone::Local => {
+                    let allowed_timezones =
+                        vec![RRuleTimeZone::Local, RRuleTimeZone::Tz(chrono_tz::Tz::UTC)];
+                    if !allowed_timezones.contains(&until.timezone()) {
+                        return Err(ValidationError::DtStartUntilMismatchTimezone {
+                            dt_start_tz: dt_start.timezone().name(),
+                            until_tz: until.timezone().name(),
+                            expected: allowed_timezones.into_iter().map(|tz| tz.name()).collect(),
+                        });
+                    }
+                }
+                _ => {
+                    if until.timezone() != RRuleTimeZone::Tz(chrono_tz::Tz::UTC) {
+                        return Err(ValidationError::DtStartUntilMismatchTimezone {
+                            dt_start_tz: dt_start.timezone().name(),
+                            until_tz: until.timezone().name(),
+                            expected: vec!["UTC".into()],
+                        });
+                    }
+                }
+            }
+
+            if until < *dt_start {
+                return Err(ValidationError::UntilBeforeStart {
+                    until: until.to_rfc3339(),
+                    dt_start: dt_start.to_rfc3339(),
+                });
+            }
+            Ok(())
+        }
         _ => Ok(()),
     }
 }
@@ -327,8 +356,8 @@ fn validate_not_equal_for_vec<T: PartialEq<T> + ToString>(
 
 #[cfg(test)]
 mod tests {
-    use chrono::TimeZone;
-    use chrono_tz::UTC;
+    use chrono::{Local, TimeZone};
+    use chrono_tz::{Europe, UTC};
 
     use super::*;
 
@@ -528,6 +557,85 @@ mod tests {
                     freq: rrule.freq
                 }
             );
+        }
+    }
+
+    #[test]
+    fn allows_until_with_compatible_timezone() {
+        fn t<T1, T2>(start_tz: T1, until_tz: T2) -> (DateTime, DateTime)
+        where
+            T1: TimeZone,
+            T2: TimeZone,
+            DateTime: From<chrono::DateTime<T1>>,
+            DateTime: From<chrono::DateTime<T2>>,
+        {
+            (
+                start_tz
+                    .ymd_opt(2020, 1, 1)
+                    .and_hms_opt(0, 0, 0)
+                    .unwrap()
+                    .into(),
+                until_tz
+                    .ymd_opt(2020, 1, 1)
+                    .and_hms_opt(0, 0, 0)
+                    .unwrap()
+                    .into(),
+            )
+        }
+
+        let tests = [t(Local, Local), t(Local, UTC), t(UTC, UTC)];
+
+        for (start_date, until) in tests {
+            let rrule = RRule {
+                until: Some(until),
+                ..Default::default()
+            };
+            let res = validate_rrule_forced(&rrule, &start_date);
+            assert!(res.is_ok());
+        }
+    }
+
+    #[test]
+    fn rejects_until_with_incompatible_timezone() {
+        fn t<T1, T2>(start_tz: T1, until_tz: T2) -> (DateTime, DateTime)
+        where
+            T1: TimeZone,
+            T2: TimeZone,
+            DateTime: From<chrono::DateTime<T1>>,
+            DateTime: From<chrono::DateTime<T2>>,
+        {
+            (
+                start_tz
+                    .ymd_opt(2020, 1, 1)
+                    .and_hms_opt(0, 0, 0)
+                    .unwrap()
+                    .into(),
+                until_tz
+                    .ymd_opt(2020, 1, 1)
+                    .and_hms_opt(0, 0, 0)
+                    .unwrap()
+                    .into(),
+            )
+        }
+
+        let tests = [
+            t(UTC, Local),
+            t(Europe::Berlin, Local),
+            t(Local, Europe::Berlin),
+        ];
+
+        for (start_date, until) in tests {
+            let rrule = RRule {
+                until: Some(until),
+                ..Default::default()
+            };
+            let res = validate_rrule_forced(&rrule, &start_date);
+            assert!(res.is_err());
+            let err = res.unwrap_err();
+            assert!(matches!(
+                err,
+                ValidationError::DtStartUntilMismatchTimezone { .. }
+            ));
         }
     }
 


### PR DESCRIPTION
This PR introduces a custom `DateTime` that replaces `chrono::DateTime<chrono_tz::Tz>` and solves a lot of use-cases for us. The problem with `chrono::DateTime<chrono_tz::Tz>` is that `chrono_tz::Tz` does not contain a local timezone whereas both `DTSTART` and `UNTIL` can be defined in local timezone. Previously we would have to store `DTSTART` as a `DateTime<Utc>` even though it was specified in local timezone. 

Here is the new `DateTime` that is able to represent Local times as well:
```rust
pub enum DateTime {
    Local(chrono::DateTime<chrono::Local>),
    Tz(chrono::DateTime<chrono_tz::Tz>),
}
```

It emulates `chrono::DateTime` by just forwarding every API call to the underlying `chrono::DateTime`. It also implements `From<chrono::DateTIme>` so that users can still use `chrono::DateTime` when setting the starte date, rdate, exdate etc. The big API difference is that iteration result returns this new `DateTime` rather than `chrono::DateTime`, but the `DateTime` can easily be converted to a `chrono::DateTime` by using the following method `DateTime::with_timezone(tz) -> chrono::DateTime`.

Fixes #49 
Fixes #74 