### PR TITLE
Change the return type of `RRuleSet::all` to a struct

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - 'main'
+  pull_request:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/tag_publish.yaml
+++ b/.github/workflows/tag_publish.yaml
@@ -1,0 +1,17 @@
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    name: publish ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+    - uses: katyo/publish-crates@v1
+      with:
+        registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased] (2022-0X-YY)
+
+### Changed
+
+- `RRuleSet::all` returns an `RRuleSetResult` struct instead of a tuple.
 
 ## 0.10.0 (2022-08-08)
 
 ### Changed
 
 - EXRULE functionality is put behind the feature flag `exrule` which is not enabled by default. 
-- `RRuleSet::all` takes a `limit` argument to protect against long running iteration.
+- `RRuleSet::all` takes a `limit` argument to protect against long-running iteration.
 - The iterator API does not have any validation limits by default. So `rrule_set.into_iter().map(|dt| format!("{dt}")).collect<Vec<_>>()` could lead to an infinite loop.
 - `RRuleSet::all` returns a tuple `(Vec<DateTime>, bool)` instead of the previous `Result` type. The boolean in the tuple indicates if the iteration was limited or not.
-- Datetime type returned from iteration is `chrono::DateTime<rrule::Tz>` rather than `chrono::DateTime<chrono_tz::Tz>`. Please use `.with_timezone` if use still want to use `chrono_tz::Tz`.
+- Datetime type returned from iteration is `chrono::DateTime<rrule::Tz>` rather than `chrono::DateTime<chrono_tz::Tz>`. Please use `.with_timezone` if you still want to use `chrono_tz::Tz`.
 
 ### Removed
 - `no-validation-limits` feature is removed and is replaced by arguments to `RRuleSet`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `RRuleSet::all` returns an `RRuleSetResult` struct instead of a tuple.
+- `RRuleSet::all` returns an `RRuleResult` struct instead of a tuple.
 
 ## 0.10.0 (2022-08-08)
 

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ check:
 	@cargo clippy --fix --allow-dirty --allow-staged --all-targets --all-features
 	@cargo update --dry-run
 	@cargo outdated -wR
-	@cargo +nightly udeps --all-targets --all-features
 	@cargo doc --no-deps --all-features --examples --document-private-items
+	@cargo +nightly udeps --all-targets --all-features
 
 check_nightly:
 	@cargo +nightly clippy --fix --allow-dirty --allow-staged --all-targets --all-features

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@ check:
 	@cargo +nightly udeps --all-targets --all-features
 	@cargo doc --no-deps --all-features --examples --document-private-items
 
-check_nightly: check
+check_nightly:
 	@cargo +nightly clippy --fix --allow-dirty --allow-staged --all-targets --all-features
 
-check_strictly: check
+check_strictly:
 	@cargo +nightly clippy --fix --allow-dirty --allow-staged --all-features --all-targets -- -W clippy::all -W clippy::pedantic -W clippy::cargo
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ let rrule: RRuleSet = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=3".parse
 // Set hard limit in case of infinitely recurring rules.
 let limit = 100;
 // Get all recurrences of the rrule
-let (recurrences, _) = rrule.all(limit);
-assert_eq!(recurrences.len(), 3);
+let result = rrule.all(limit);
+assert_eq!(result.dates.len(), 3);
 ```
 
 See more examples at [docs.rs](https://docs.rs/rrule)

--- a/rrule-debugger/src/debug.rs
+++ b/rrule-debugger/src/debug.rs
@@ -15,9 +15,9 @@ fn test_from_string() {
         .parse()
         .unwrap();
     println!("RRule: {:#?}", rrule);
-    let (list, limited) = rrule.all(20);
-    println!("Limited: {}", limited);
-    crate::print_all_datetimes(&list);
+    let result = rrule.all(20);
+    println!("Limited: {}", result.limited);
+    crate::print_all_datetimes(&result.list);
 }
 
 fn test_parsed_rrule() {
@@ -29,10 +29,10 @@ fn test_parsed_rrule() {
         .by_second(vec![0]);
 
     let rrule = properties.build(ymd_hms(1997, 9, 2, 9, 0, 0)).unwrap();
-    let (list, limited) = rrule.all(50);
+    let result = rrule.all(50);
 
-    println!("Limited: {}", limited);
-    crate::print_all_datetimes(&list);
+    println!("Limited: {}", result.limited);
+    crate::print_all_datetimes(&result.list);
 }
 
 fn ymd_hms(year: i32, month: u32, day: u32, hour: u32, minute: u32, second: u32) -> DateTime<Tz> {

--- a/rrule-debugger/src/debug.rs
+++ b/rrule-debugger/src/debug.rs
@@ -17,7 +17,7 @@ fn test_from_string() {
     println!("RRule: {:#?}", rrule);
     let result = rrule.all(20);
     println!("Limited: {}", result.limited);
-    crate::print_all_datetimes(&result.list);
+    crate::print_all_datetimes(&result.dates);
 }
 
 fn test_parsed_rrule() {
@@ -32,7 +32,7 @@ fn test_parsed_rrule() {
     let result = rrule.all(50);
 
     println!("Limited: {}", result.limited);
-    crate::print_all_datetimes(&result.list);
+    crate::print_all_datetimes(&result.dates);
 }
 
 fn ymd_hms(year: i32, month: u32, day: u32, hour: u32, minute: u32, second: u32) -> DateTime<Tz> {

--- a/rrule-debugger/src/iter_rrule.rs
+++ b/rrule-debugger/src/iter_rrule.rs
@@ -12,9 +12,9 @@ pub fn rrule_from_bin(data: &[u8]) {
     match rrule_afl_fuzz::take_rrule::take_rrule_from_data(data) {
         Some(rule) => {
             println!("RRule data: {:#?}", rule);
-            let (list, limited) = rule.all(50);
-            crate::print_all_datetimes(&list);
-            if limited {
+            let result = rule.all(50);
+            crate::print_all_datetimes(&result.list);
+            if result.limited {
                 println!("RRule was limited");
             }
         }

--- a/rrule-debugger/src/iter_rrule.rs
+++ b/rrule-debugger/src/iter_rrule.rs
@@ -13,7 +13,7 @@ pub fn rrule_from_bin(data: &[u8]) {
         Some(rule) => {
             println!("RRule data: {:#?}", rule);
             let result = rule.all(50);
-            crate::print_all_datetimes(&result.list);
+            crate::print_all_datetimes(&result.dates);
             if result.limited {
                 println!("RRule was limited");
             }

--- a/rrule-debugger/src/parser_rrule.rs
+++ b/rrule-debugger/src/parser_rrule.rs
@@ -18,7 +18,7 @@ pub fn parse_rrule_from_string(rrule: &str) {
         Ok(rrule) => {
             println!("RRule data: {:#?}", rrule);
             let result = rrule.all(50);
-            crate::print_all_datetimes(&result.list);
+            crate::print_all_datetimes(&result.dates);
             if result.limited {
                 println!("RRule was limited");
             }

--- a/rrule-debugger/src/parser_rrule.rs
+++ b/rrule-debugger/src/parser_rrule.rs
@@ -17,9 +17,9 @@ pub fn parse_rrule_from_string(rrule: &str) {
     match RRuleSet::from_str(rrule) {
         Ok(rrule) => {
             println!("RRule data: {:#?}", rrule);
-            let (list, limited) = rrule.all(50);
-            crate::print_all_datetimes(&list);
-            if limited {
+            let result = rrule.all(50);
+            crate::print_all_datetimes(&result.list);
+            if result.limited {
                 println!("RRule was limited");
             }
         }

--- a/rrule/examples/manual_rrule_set.rs
+++ b/rrule/examples/manual_rrule_set.rs
@@ -30,7 +30,7 @@ fn main() {
             .validate(Tz::UTC.ymd(2020, 1, 1).and_hms(9, 0, 0))
             .expect("RRule invalid");
 
-        let recurrences = rrule_set.exrule(exrule).all(10).list;
+        let recurrences = rrule_set.exrule(exrule).all(10).dates;
 
         // Check that all the recurrences are on a Tuesday
         for occurrence in &recurrences {

--- a/rrule/examples/manual_rrule_set.rs
+++ b/rrule/examples/manual_rrule_set.rs
@@ -30,7 +30,7 @@ fn main() {
             .validate(Tz::UTC.ymd(2020, 1, 1).and_hms(9, 0, 0))
             .expect("RRule invalid");
 
-        let recurrences = rrule_set.exrule(exrule).all(10).0;
+        let recurrences = rrule_set.exrule(exrule).all(10).list;
 
         // Check that all the recurrences are on a Tuesday
         for occurrence in &recurrences {

--- a/rrule/src/bin/rrule.rs
+++ b/rrule/src/bin/rrule.rs
@@ -61,11 +61,8 @@ where
 {
     for _ in 0..limit {
         let next = rule_iter.next();
-        match next {
-            Some(value) => {
-                println!("{}", value);
-            }
-            None => {}
+        if let Some(value) = next {
+            println!("{}", value);
         }
     }
 }

--- a/rrule/src/core/mod.rs
+++ b/rrule/src/core/mod.rs
@@ -6,7 +6,7 @@ mod timezone_impl;
 pub(crate) mod utils;
 
 pub use self::rrule::{Frequency, NWeekday, RRule};
-pub use self::rruleset::RRuleSet;
+pub use self::rruleset::{RRuleSet, RRuleSetResult};
 pub(crate) use datetime::{
     duration_from_midnight, get_day, get_hour, get_minute, get_month, get_second, DateTime,
 };

--- a/rrule/src/core/mod.rs
+++ b/rrule/src/core/mod.rs
@@ -6,7 +6,7 @@ mod timezone_impl;
 pub(crate) mod utils;
 
 pub use self::rrule::{Frequency, NWeekday, RRule};
-pub use self::rruleset::{RRuleSet, RRuleResult};
+pub use self::rruleset::{RRuleResult, RRuleSet};
 pub(crate) use datetime::{
     duration_from_midnight, get_day, get_hour, get_minute, get_month, get_second, DateTime,
 };

--- a/rrule/src/core/mod.rs
+++ b/rrule/src/core/mod.rs
@@ -6,7 +6,7 @@ mod timezone_impl;
 pub(crate) mod utils;
 
 pub use self::rrule::{Frequency, NWeekday, RRule};
-pub use self::rruleset::{RRuleSet, RRuleSetResult};
+pub use self::rruleset::{RRuleSet, RRuleResult};
 pub(crate) use datetime::{
     duration_from_midnight, get_day, get_hour, get_minute, get_month, get_second, DateTime,
 };

--- a/rrule/src/core/rrule.rs
+++ b/rrule/src/core/rrule.rs
@@ -4,12 +4,13 @@ use crate::core::get_hour;
 use crate::core::get_minute;
 use crate::core::get_month;
 use crate::core::get_second;
+use crate::iter::RRuleIter;
 use crate::parser::str_to_weekday;
 use crate::parser::ContentLineCaptures;
 use crate::parser::ParseError;
 use crate::validator::validate_rrule;
 use crate::validator::ValidationError;
-use crate::{RRuleError, RRuleIter, RRuleSet, Unvalidated, Validated};
+use crate::{RRuleError, RRuleSet, Unvalidated, Validated};
 use chrono::{Datelike, Month, Weekday};
 #[cfg(feature = "serde")]
 use serde_with::{serde_as, DeserializeFromStr, SerializeDisplay};

--- a/rrule/src/core/rruleset.rs
+++ b/rrule/src/core/rruleset.rs
@@ -183,9 +183,9 @@ impl RRuleSet {
     /// let rrule_set: RRuleSet = "DTSTART:20210101T090000Z\nRRULE:FREQ=DAILY".parse().unwrap();
     ///
     /// // Limit the results to 2 recurrences
-    /// let (result, limited) = rrule_set.all(2);
-    /// assert_eq!(result.len(), 2);
-    /// assert_eq!(limited, true);
+    /// let result = rrule_set.all(2);
+    /// assert_eq!(result.list.len(), 2);
+    /// assert_eq!(result.limited, true);
     /// ```
     #[must_use]
     pub fn all(mut self, limit: u16) -> RRuleSetResult {

--- a/rrule/src/core/rruleset.rs
+++ b/rrule/src/core/rruleset.rs
@@ -32,9 +32,9 @@ pub struct RRuleSet {
 }
 
 /// The return result of `RRuleSet::all`.
-pub struct RRuleSetResult {
+pub struct RRuleResult {
     /// List of recurrences.
-    pub list: Vec<DateTime>,
+    pub dates: Vec<DateTime>,
     /// If recurrence is limited
     pub limited: bool,
 }
@@ -184,11 +184,11 @@ impl RRuleSet {
     ///
     /// // Limit the results to 2 recurrences
     /// let result = rrule_set.all(2);
-    /// assert_eq!(result.list.len(), 2);
+    /// assert_eq!(result.dates.len(), 2);
     /// assert_eq!(result.limited, true);
     /// ```
     #[must_use]
-    pub fn all(mut self, limit: u16) -> RRuleSetResult {
+    pub fn all(mut self, limit: u16) -> RRuleResult {
         self.limited = true;
         collect_with_error(
             self.into_iter(),
@@ -207,7 +207,7 @@ impl RRuleSet {
     /// very long iteration times. Please read the `SECURITY.md` for more information.
     #[must_use]
     pub fn all_unchecked(self) -> Vec<DateTime> {
-        collect_with_error(self.into_iter(), &self.after, &self.before, true, None).list
+        collect_with_error(self.into_iter(), &self.after, &self.before, true, None).dates
     }
 }
 

--- a/rrule/src/core/rruleset.rs
+++ b/rrule/src/core/rruleset.rs
@@ -31,6 +31,14 @@ pub struct RRuleSet {
     pub(crate) limited: bool,
 }
 
+/// A validated Recurrence Rule that can be used to create an iterator.
+pub struct RRuleSetResult {
+    /// List of recurrences.
+    pub list: Vec<DateTime>,
+    /// If recurrence are truncated
+    pub limited: bool,
+}
+
 impl RRuleSet {
     /// Creates an empty [`RRuleSet`], starting from `ds_start`.
     #[must_use]
@@ -180,7 +188,7 @@ impl RRuleSet {
     /// assert_eq!(limited, true);
     /// ```
     #[must_use]
-    pub fn all(mut self, limit: u16) -> (Vec<DateTime>, bool) {
+    pub fn all(mut self, limit: u16) -> RRuleSetResult {
         self.limited = true;
         collect_with_error(
             self.into_iter(),
@@ -199,7 +207,7 @@ impl RRuleSet {
     /// very long iteration times. Please read the `SECURITY.md` for more information.
     #[must_use]
     pub fn all_unchecked(self) -> Vec<DateTime> {
-        collect_with_error(self.into_iter(), &self.after, &self.before, true, None).0
+        collect_with_error(self.into_iter(), &self.after, &self.before, true, None).list
     }
 }
 

--- a/rrule/src/core/rruleset.rs
+++ b/rrule/src/core/rruleset.rs
@@ -35,7 +35,7 @@ pub struct RRuleSet {
 pub struct RRuleResult {
     /// List of recurrences.
     pub dates: Vec<DateTime>,
-    /// If recurrence is limited
+    /// It is be true, if the list of dates is limited. To indicate that it can potentially contain more dates.
     pub limited: bool,
 }
 

--- a/rrule/src/core/rruleset.rs
+++ b/rrule/src/core/rruleset.rs
@@ -31,11 +31,11 @@ pub struct RRuleSet {
     pub(crate) limited: bool,
 }
 
-/// A validated Recurrence Rule that can be used to create an iterator.
+/// The return result of `RRuleSet::all`.
 pub struct RRuleSetResult {
     /// List of recurrences.
     pub list: Vec<DateTime>,
-    /// If recurrence are truncated
+    /// If recurrence is limited
     pub limited: bool,
 }
 

--- a/rrule/src/core/utils.rs
+++ b/rrule/src/core/utils.rs
@@ -17,8 +17,8 @@ pub(super) fn collect_with_error<T>(
     inclusive: bool,
     limit: Option<u16>,
 ) -> RRuleSetResult
-    where
-        T: Iterator<Item=DateTime> + WasLimited,
+where
+    T: Iterator<Item = DateTime> + WasLimited,
 {
     let mut list = vec![];
     let mut was_limited = false;

--- a/rrule/src/core/utils.rs
+++ b/rrule/src/core/utils.rs
@@ -1,6 +1,6 @@
 use super::DateTime;
 use crate::iter::rrule_iter::WasLimited;
-use crate::RRuleSetResult;
+use crate::RRuleResult;
 use std::ops::{
     Bound::{Excluded, Unbounded},
     RangeBounds,
@@ -16,7 +16,7 @@ pub(super) fn collect_with_error<T>(
     end: &Option<DateTime>,
     inclusive: bool,
     limit: Option<u16>,
-) -> RRuleSetResult
+) -> RRuleResult
 where
     T: Iterator<Item = DateTime> + WasLimited,
 {
@@ -44,8 +44,8 @@ where
 
     was_limited = was_limited || matches!(limit, Some(limit) if usize::from(limit) == list.len());
 
-    RRuleSetResult {
-        list,
+    RRuleResult {
+        dates: list,
         limited: was_limited,
     }
 }

--- a/rrule/src/core/utils.rs
+++ b/rrule/src/core/utils.rs
@@ -1,5 +1,6 @@
 use super::DateTime;
 use crate::iter::rrule_iter::WasLimited;
+use crate::RRuleSetResult;
 use std::ops::{
     Bound::{Excluded, Unbounded},
     RangeBounds,
@@ -15,9 +16,9 @@ pub(super) fn collect_with_error<T>(
     end: &Option<DateTime>,
     inclusive: bool,
     limit: Option<u16>,
-) -> (Vec<DateTime>, bool)
-where
-    T: Iterator<Item = DateTime> + WasLimited,
+) -> RRuleSetResult
+    where
+        T: Iterator<Item=DateTime> + WasLimited,
 {
     let mut list = vec![];
     let mut was_limited = false;
@@ -43,7 +44,10 @@ where
 
     was_limited = was_limited || matches!(limit, Some(limit) if usize::from(limit) == list.len());
 
-    (list, was_limited)
+    RRuleSetResult {
+        list,
+        limited: was_limited,
+    }
 }
 
 /// Checks if `date` is after `end`.
@@ -106,21 +110,21 @@ mod tests {
             &UTC.ymd(2021, 10, 1).and_hms(9, 0, 0),
             &Some(start),
             &Some(end),
-            inclusive
+            inclusive,
         ));
         // To small
         assert!(!is_in_range(
             &UTC.ymd(2021, 10, 1).and_hms(7, 0, 0),
             &Some(start),
             &Some(end),
-            inclusive
+            inclusive,
         ));
         // To big
         assert!(!is_in_range(
             &UTC.ymd(2021, 10, 1).and_hms(11, 0, 0),
             &Some(start),
             &Some(end),
-            inclusive
+            inclusive,
         ));
         // Equal to end
         assert!(!is_in_range(&end, &Some(start), &Some(end), inclusive));
@@ -138,21 +142,21 @@ mod tests {
             &UTC.ymd(2021, 10, 1).and_hms(9, 0, 0),
             &Some(start),
             &None,
-            inclusive
+            inclusive,
         ));
         // To small
         assert!(!is_in_range(
             &UTC.ymd(2021, 10, 1).and_hms(7, 0, 0),
             &Some(start),
             &None,
-            inclusive
+            inclusive,
         ));
         // Bigger
         assert!(is_in_range(
             &UTC.ymd(2021, 10, 2).and_hms(8, 0, 0),
             &Some(start),
             &None,
-            inclusive
+            inclusive,
         ));
         // Equal to start
         assert!(!is_in_range(&start, &Some(start), &None, inclusive));
@@ -168,21 +172,21 @@ mod tests {
             &UTC.ymd(2021, 10, 1).and_hms(9, 0, 0),
             &None,
             &Some(end),
-            inclusive
+            inclusive,
         ));
         // Smaller
         assert!(is_in_range(
             &UTC.ymd(2021, 9, 20).and_hms(10, 0, 0),
             &None,
             &Some(end),
-            inclusive
+            inclusive,
         ));
         // Bigger
         assert!(!is_in_range(
             &UTC.ymd(2021, 10, 2).and_hms(8, 0, 0),
             &None,
             &Some(end),
-            inclusive
+            inclusive,
         ));
         // Equal to end
         assert!(!is_in_range(&end, &None, &Some(end), inclusive));
@@ -197,21 +201,21 @@ mod tests {
             &UTC.ymd(2021, 10, 1).and_hms(9, 0, 0),
             &None,
             &None,
-            inclusive
+            inclusive,
         ));
         // Smaller
         assert!(is_in_range(
             &UTC.ymd(2021, 9, 20).and_hms(10, 0, 0),
             &None,
             &None,
-            inclusive
+            inclusive,
         ));
         // Bigger
         assert!(is_in_range(
             &UTC.ymd(2021, 10, 2).and_hms(8, 0, 0),
             &None,
             &None,
-            inclusive
+            inclusive,
         ));
     }
 
@@ -228,21 +232,21 @@ mod tests {
             &UTC.ymd(2021, 10, 1).and_hms(9, 0, 0),
             &Some(start),
             &Some(end),
-            inclusive
+            inclusive,
         ));
         // To small
         assert!(!is_in_range(
             &UTC.ymd(2021, 10, 1).and_hms(7, 0, 0),
             &Some(start),
             &Some(end),
-            inclusive
+            inclusive,
         ));
         // To big
         assert!(!is_in_range(
             &UTC.ymd(2021, 10, 1).and_hms(11, 0, 0),
             &Some(start),
             &Some(end),
-            inclusive
+            inclusive,
         ));
         // Equal to end
         assert!(is_in_range(&end, &Some(start), &Some(end), inclusive));
@@ -260,21 +264,21 @@ mod tests {
             &UTC.ymd(2021, 10, 1).and_hms(9, 0, 0),
             &Some(start),
             &None,
-            inclusive
+            inclusive,
         ));
         // To small
         assert!(!is_in_range(
             &UTC.ymd(2021, 10, 1).and_hms(7, 0, 0),
             &Some(start),
             &None,
-            inclusive
+            inclusive,
         ));
         // Bigger
         assert!(is_in_range(
             &UTC.ymd(2021, 10, 2).and_hms(8, 0, 0),
             &Some(start),
             &None,
-            inclusive
+            inclusive,
         ));
         // Equal to start
         assert!(is_in_range(&start, &Some(start), &None, inclusive));
@@ -290,21 +294,21 @@ mod tests {
             &UTC.ymd(2021, 10, 1).and_hms(9, 0, 0),
             &None,
             &Some(end),
-            inclusive
+            inclusive,
         ));
         // Smaller
         assert!(is_in_range(
             &UTC.ymd(2021, 9, 20).and_hms(10, 0, 0),
             &None,
             &Some(end),
-            inclusive
+            inclusive,
         ));
         // Bigger
         assert!(!is_in_range(
             &UTC.ymd(2021, 10, 2).and_hms(8, 0, 0),
             &None,
             &Some(end),
-            inclusive
+            inclusive,
         ));
         // Equal to end
         assert!(is_in_range(&end, &None, &Some(end), inclusive));
@@ -319,21 +323,21 @@ mod tests {
             &UTC.ymd(2021, 10, 1).and_hms(9, 0, 0),
             &None,
             &None,
-            inclusive
+            inclusive,
         ));
         // Smaller
         assert!(is_in_range(
             &UTC.ymd(2021, 9, 20).and_hms(10, 0, 0),
             &None,
             &None,
-            inclusive
+            inclusive,
         ));
         // Bigger
         assert!(is_in_range(
             &UTC.ymd(2021, 10, 2).and_hms(8, 0, 0),
             &None,
             &None,
-            inclusive
+            inclusive,
         ));
     }
 }

--- a/rrule/src/error.rs
+++ b/rrule/src/error.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 
 use crate::{parser::ParseError, validator::ValidationError};
 
-#[derive(Error, Debug, Clone, PartialEq)]
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
 /// The error type for the rrule crate.
 pub enum RRuleError {
     /// Parsing error

--- a/rrule/src/iter/utils.rs
+++ b/rrule/src/iter/utils.rs
@@ -75,7 +75,7 @@ where
 
 pub(crate) fn add_time_to_date(date: Date<Tz>, time: NaiveTime) -> Option<DateTime> {
     if let Some(dt) = date.and_time(time) {
-        return Some(dt)
+        return Some(dt);
     }
     // If the day is a daylight saving time, the above code might now work and we
     // can try to get a valid datetime by adding the `time` as a duration instead.

--- a/rrule/src/iter/utils.rs
+++ b/rrule/src/iter/utils.rs
@@ -74,9 +74,8 @@ where
 }
 
 pub(crate) fn add_time_to_date(date: Date<Tz>, time: NaiveTime) -> Option<DateTime> {
-    match date.and_time(time) {
-        Some(dt) => return Some(dt),
-        None => (),
+    if let Some(dt) = date.and_time(time) {
+        return Some(dt)
     }
     // If the day is a daylight saving time, the above code might now work and we
     // can try to get a valid datetime by adding the `time` as a duration instead.

--- a/rrule/src/lib.rs
+++ b/rrule/src/lib.rs
@@ -50,7 +50,7 @@
 //! use rrule::{RRuleSet, Tz};
 //!
 //! let rrule: RRuleSet = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=3".parse().unwrap();
-//! let (events, _) = rrule.all(100);
+//! let result = rrule.all(100);
 //!
 //! // All dates
 //! assert_eq!(
@@ -59,7 +59,7 @@
 //!         DateTime::parse_from_rfc3339("2012-02-02T09:30:00+00:00").unwrap(),
 //!         DateTime::parse_from_rfc3339("2012-02-03T09:30:00+00:00").unwrap(),
 //!     ],
-//!     events
+//!     result.list
 //! );
 //! ```
 //! Find all events that are within a given range.
@@ -74,14 +74,14 @@
 //! let before = Tz::UTC.ymd(2012, 4, 1).and_hms(9, 0, 0);
 //!
 //! let rrule = rrule.after(after).before(before);
-//! let (events, _) = rrule.all(100);
+//! let result = rrule.all(100);
 //!
 //! assert_eq!(
 //!     vec![
 //!         DateTime::parse_from_rfc3339("2012-02-02T09:30:00+00:00").unwrap(),
 //!         DateTime::parse_from_rfc3339("2012-02-03T09:30:00+00:00").unwrap(),
 //!     ],
-//!     events
+//!     result.list
 //! );
 //! ```
 //!

--- a/rrule/src/lib.rs
+++ b/rrule/src/lib.rs
@@ -100,9 +100,8 @@ mod parser;
 mod tests;
 mod validator;
 
-pub use crate::core::{Frequency, NWeekday, RRule, RRuleSet, Tz};
+pub use crate::core::{Frequency, NWeekday, RRule, RRuleSet, RRuleSetResult, Tz};
 pub use crate::core::{Unvalidated, Validated};
 pub use chrono::Weekday;
 pub use error::RRuleError;
-pub(crate) use iter::RRuleIter;
 pub use iter::RRuleSetIter;

--- a/rrule/src/lib.rs
+++ b/rrule/src/lib.rs
@@ -100,7 +100,7 @@ mod parser;
 mod tests;
 mod validator;
 
-pub use crate::core::{Frequency, NWeekday, RRule, RRuleSet, RRuleResult, Tz};
+pub use crate::core::{Frequency, NWeekday, RRule, RRuleResult, RRuleSet, Tz};
 pub use crate::core::{Unvalidated, Validated};
 pub use chrono::Weekday;
 pub use error::RRuleError;

--- a/rrule/src/lib.rs
+++ b/rrule/src/lib.rs
@@ -59,7 +59,7 @@
 //!         DateTime::parse_from_rfc3339("2012-02-02T09:30:00+00:00").unwrap(),
 //!         DateTime::parse_from_rfc3339("2012-02-03T09:30:00+00:00").unwrap(),
 //!     ],
-//!     result.list
+//!     result.dates
 //! );
 //! ```
 //! Find all events that are within a given range.
@@ -81,7 +81,7 @@
 //!         DateTime::parse_from_rfc3339("2012-02-02T09:30:00+00:00").unwrap(),
 //!         DateTime::parse_from_rfc3339("2012-02-03T09:30:00+00:00").unwrap(),
 //!     ],
-//!     result.list
+//!     result.dates
 //! );
 //! ```
 //!
@@ -100,7 +100,7 @@ mod parser;
 mod tests;
 mod validator;
 
-pub use crate::core::{Frequency, NWeekday, RRule, RRuleSet, RRuleSetResult, Tz};
+pub use crate::core::{Frequency, NWeekday, RRule, RRuleSet, RRuleResult, Tz};
 pub use crate::core::{Unvalidated, Validated};
 pub use chrono::Weekday;
 pub use error::RRuleError;

--- a/rrule/src/parser/error.rs
+++ b/rrule/src/parser/error.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::module_name_repetitions)]
 use thiserror::Error;
 
-#[derive(Error, Debug, Clone, PartialEq)]
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum ParseError {
     #[error("`{0}` is not a valid timezone.")]
     InvalidTimezone(String),

--- a/rrule/src/tests/common.rs
+++ b/rrule/src/tests/common.rs
@@ -30,10 +30,10 @@ pub fn test_recurring_rrule(
             RRuleError::IterError(e) => e,
         })
         .unwrap();
-    let res = if !limited {
-        rrule_set.all_unchecked()
+    let res = if limited {
+        rrule_set.all(u16::MAX).list
     } else {
-        rrule_set.all(u16::MAX).0
+        rrule_set.all_unchecked()
     };
 
     println!("Actual: {:?}", res);
@@ -51,7 +51,7 @@ pub fn test_recurring_rrule(
 
 #[allow(clippy::needless_pass_by_value)]
 pub fn test_recurring_rrule_set(rrule_set: RRuleSet, expected_dates: &[DateTime<Tz>]) {
-    let res = rrule_set.all(u16::MAX).0;
+    let res = rrule_set.all(u16::MAX).list;
 
     println!("Actual: {:?}", res);
     println!("Expected: {:?}", expected_dates);

--- a/rrule/src/tests/common.rs
+++ b/rrule/src/tests/common.rs
@@ -31,7 +31,7 @@ pub fn test_recurring_rrule(
         })
         .unwrap();
     let res = if limited {
-        rrule_set.all(u16::MAX).list
+        rrule_set.all(u16::MAX).dates
     } else {
         rrule_set.all_unchecked()
     };
@@ -51,7 +51,7 @@ pub fn test_recurring_rrule(
 
 #[allow(clippy::needless_pass_by_value)]
 pub fn test_recurring_rrule_set(rrule_set: RRuleSet, expected_dates: &[DateTime<Tz>]) {
-    let res = rrule_set.all(u16::MAX).list;
+    let res = rrule_set.all(u16::MAX).dates;
 
     println!("Actual: {:?}", res);
     println!("Expected: {:?}", expected_dates);

--- a/rrule/src/tests/datetime.rs
+++ b/rrule/src/tests/datetime.rs
@@ -9,7 +9,7 @@ fn monthly_on_31th() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .0;
+        .list;
     // TODO: Is this the correct behavior?
     common::check_occurrences(
         &dates,
@@ -36,7 +36,7 @@ fn monthly_on_31th_to_last() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .0;
+        .list;
     // TODO: Is this the correct behavior?
     common::check_occurrences(
         &dates,

--- a/rrule/src/tests/datetime.rs
+++ b/rrule/src/tests/datetime.rs
@@ -9,7 +9,7 @@ fn monthly_on_31th() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .list;
+        .dates;
     // TODO: Is this the correct behavior?
     common::check_occurrences(
         &dates,
@@ -36,7 +36,7 @@ fn monthly_on_31th_to_last() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .list;
+        .dates;
     // TODO: Is this the correct behavior?
     common::check_occurrences(
         &dates,

--- a/rrule/src/tests/daylight_saving.rs
+++ b/rrule/src/tests/daylight_saving.rs
@@ -52,7 +52,7 @@ fn daylight_savings_2() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .list;
+        .dates;
     check_occurrences(
         &dates,
         &[

--- a/rrule/src/tests/daylight_saving.rs
+++ b/rrule/src/tests/daylight_saving.rs
@@ -52,7 +52,7 @@ fn daylight_savings_2() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .0;
+        .list;
     check_occurrences(
         &dates,
         &[

--- a/rrule/src/tests/regression.rs
+++ b/rrule/src/tests/regression.rs
@@ -8,7 +8,7 @@ RRULE:FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=-2"
         .parse::<RRuleSet>()
         .unwrap()
         .all(7)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -29,7 +29,7 @@ fn issue_49() {
         .parse::<RRuleSet>()
         .expect("The RRule is not valid");
 
-    let res = rrule_set.all(1).list;
+    let res = rrule_set.all(1).dates;
     assert!(!res.is_empty());
     let res_str = format!("{}", res[0]);
     // Check that result datetime is not in UTC
@@ -42,6 +42,6 @@ fn issue_61() {
         .parse::<RRuleSet>()
         .expect("The RRule is not valid");
 
-    let res = rrule_set.all(10).list;
+    let res = rrule_set.all(10).dates;
     assert_eq!(res.len(), 10);
 }

--- a/rrule/src/tests/regression.rs
+++ b/rrule/src/tests/regression.rs
@@ -8,7 +8,7 @@ RRULE:FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=-2"
         .parse::<RRuleSet>()
         .unwrap()
         .all(7)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -29,7 +29,7 @@ fn issue_49() {
         .parse::<RRuleSet>()
         .expect("The RRule is not valid");
 
-    let res = rrule_set.all(1).0;
+    let res = rrule_set.all(1).list;
     assert!(!res.is_empty());
     let res_str = format!("{}", res[0]);
     // Check that result datetime is not in UTC
@@ -42,6 +42,6 @@ fn issue_61() {
         .parse::<RRuleSet>()
         .expect("The RRule is not valid");
 
-    let res = rrule_set.all(10).0;
+    let res = rrule_set.all(10).list;
     assert_eq!(res.len(), 10);
 }

--- a/rrule/src/tests/rfc_tests.rs
+++ b/rrule/src/tests/rfc_tests.rs
@@ -14,7 +14,7 @@ fn daily_10_occurrences() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -42,7 +42,7 @@ fn daily_until_november() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -106,7 +106,7 @@ fn every_other_day() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(32)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -154,7 +154,7 @@ fn every_10_days_5_occurrences() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -176,13 +176,13 @@ fn every_days_in_jan_for_3_years() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(100)
-        .list;
+        .dates;
     let dates_alt = "DTSTART;TZID=America/New_York:19980101T090000\n\
         RRULE:FREQ=DAILY;UNTIL=20000131T140000Z;BYMONTH=1"
         .parse::<RRuleSet>()
         .unwrap()
         .all(100)
-        .list;
+        .dates;
     let mut expected = vec![];
     for year in 1998..=2000 {
         for day in 1..=31 {
@@ -203,7 +203,7 @@ fn weekly_10_occurrences() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -231,7 +231,7 @@ fn weekly_until_november() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -258,7 +258,7 @@ fn every_other_week() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(13)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -287,13 +287,13 @@ fn weekly_on_tue_and_thu_for_5_weeks() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .list;
+        .dates;
     let dates_alt = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=WEEKLY;COUNT=10;WKST=SU;BYDAY=TU,TH"
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .list;
+        .dates;
     let expected = vec![
         "1997-09-02T09:00:00-04:00",
         "1997-09-04T09:00:00-04:00",
@@ -319,7 +319,7 @@ fn every_other_week_some_days_until_dec() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -360,7 +360,7 @@ fn every_other_week_some_days_8_occurrences() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -386,7 +386,7 @@ fn monthly_on_first_friday_10_occurrences() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -412,7 +412,7 @@ fn monthly_on_first_friday_until_dec() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -432,7 +432,7 @@ fn every_other_month_on_first_and_last_sunday_10_occurrences() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -458,7 +458,7 @@ fn monthly_on_second_to_last_monday_for_6_months() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -480,7 +480,7 @@ fn monthly_on_third_to_last_day_forever() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(6)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -502,7 +502,7 @@ fn monthly_on_2nd_and_15th_10_occurrences() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -528,7 +528,7 @@ fn monthly_on_first_and_last_day_10_occurrences() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -554,7 +554,7 @@ fn every_18_months_10th_to_15th_10_occurrences() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -580,7 +580,7 @@ fn every_tuesday_every_other_month() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(18)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -619,7 +619,7 @@ fn yearly_in_june_and_july_for_10_occurrences() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -645,7 +645,7 @@ fn every_other_year_on_jan_feb_and_march_for_10_occurrences() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -671,7 +671,7 @@ fn every_third_year_on_1st_100th_and_200th_day_for_10_occurrences() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -697,7 +697,7 @@ fn every_20th_monday_of_year_forever() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(3)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -716,7 +716,7 @@ fn monday_of_week_20_forever() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(3)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -735,7 +735,7 @@ fn every_thursday_in_march_forever() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(11)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -762,7 +762,7 @@ fn every_thursday_only_during_june_july_and_august_forever() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(39)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -818,7 +818,7 @@ fn every_friday_the_13th_forever() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(5)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -839,7 +839,7 @@ fn first_sat_follows_first_sunday_of_month_forever() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(10)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -866,7 +866,7 @@ fn every_4_years_us_presidential_election_day_forever() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(3)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -886,7 +886,7 @@ fn every_third_instance_of_weekday_in_month_for_3_months() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -905,7 +905,7 @@ fn second_to_last_weekday_of_month() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(7)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -929,7 +929,7 @@ fn every_3_hours_on_specific_day() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -948,7 +948,7 @@ fn every_15_min_for_6_occurrences() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -970,7 +970,7 @@ fn every_hour_and_a_half_for_4_occurrences() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -990,13 +990,13 @@ fn every_20_min_at_time_every_day() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(72)
-        .list;
+        .dates;
     let dates_alt = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=MINUTELY;INTERVAL=20;BYHOUR=9,10,11,12,13,14,15,16"
         .parse::<RRuleSet>()
         .unwrap()
         .all(72)
-        .list;
+        .dates;
 
     let mut expected = vec![];
     for day in 2..=4 {
@@ -1039,7 +1039,7 @@ fn week_day_start_monday_generated_days() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -1059,7 +1059,7 @@ fn week_day_start_sunday_generated_days() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[
@@ -1079,7 +1079,7 @@ fn invalid_date_is_ignored() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .list;
+        .dates;
     common::check_occurrences(
         &dates,
         &[

--- a/rrule/src/tests/rfc_tests.rs
+++ b/rrule/src/tests/rfc_tests.rs
@@ -14,7 +14,7 @@ fn daily_10_occurrences() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -42,7 +42,7 @@ fn daily_until_november() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -106,7 +106,7 @@ fn every_other_day() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(32)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -154,7 +154,7 @@ fn every_10_days_5_occurrences() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -176,13 +176,13 @@ fn every_days_in_jan_for_3_years() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(100)
-        .0;
+        .list;
     let dates_alt = "DTSTART;TZID=America/New_York:19980101T090000\n\
         RRULE:FREQ=DAILY;UNTIL=20000131T140000Z;BYMONTH=1"
         .parse::<RRuleSet>()
         .unwrap()
         .all(100)
-        .0;
+        .list;
     let mut expected = vec![];
     for year in 1998..=2000 {
         for day in 1..=31 {
@@ -203,7 +203,7 @@ fn weekly_10_occurrences() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -231,7 +231,7 @@ fn weekly_until_november() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -258,7 +258,7 @@ fn every_other_week() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(13)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -287,13 +287,13 @@ fn weekly_on_tue_and_thu_for_5_weeks() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .0;
+        .list;
     let dates_alt = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=WEEKLY;COUNT=10;WKST=SU;BYDAY=TU,TH"
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .0;
+        .list;
     let expected = vec![
         "1997-09-02T09:00:00-04:00",
         "1997-09-04T09:00:00-04:00",
@@ -319,7 +319,7 @@ fn every_other_week_some_days_until_dec() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -360,7 +360,7 @@ fn every_other_week_some_days_8_occurrences() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -386,7 +386,7 @@ fn monthly_on_first_friday_10_occurrences() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -412,7 +412,7 @@ fn monthly_on_first_friday_until_dec() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -432,7 +432,7 @@ fn every_other_month_on_first_and_last_sunday_10_occurrences() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -458,7 +458,7 @@ fn monthly_on_second_to_last_monday_for_6_months() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -480,7 +480,7 @@ fn monthly_on_third_to_last_day_forever() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(6)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -502,7 +502,7 @@ fn monthly_on_2nd_and_15th_10_occurrences() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -528,7 +528,7 @@ fn monthly_on_first_and_last_day_10_occurrences() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -554,7 +554,7 @@ fn every_18_months_10th_to_15th_10_occurrences() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -580,7 +580,7 @@ fn every_tuesday_every_other_month() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(18)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -619,7 +619,7 @@ fn yearly_in_june_and_july_for_10_occurrences() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -645,7 +645,7 @@ fn every_other_year_on_jan_feb_and_march_for_10_occurrences() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -671,7 +671,7 @@ fn every_third_year_on_1st_100th_and_200th_day_for_10_occurrences() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -697,7 +697,7 @@ fn every_20th_monday_of_year_forever() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(3)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -716,7 +716,7 @@ fn monday_of_week_20_forever() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(3)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -735,7 +735,7 @@ fn every_thursday_in_march_forever() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(11)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -762,7 +762,7 @@ fn every_thursday_only_during_june_july_and_august_forever() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(39)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -818,7 +818,7 @@ fn every_friday_the_13th_forever() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(5)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -839,7 +839,7 @@ fn first_sat_follows_first_sunday_of_month_forever() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(10)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -866,7 +866,7 @@ fn every_4_years_us_presidential_election_day_forever() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(3)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -886,7 +886,7 @@ fn every_third_instance_of_weekday_in_month_for_3_months() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -905,7 +905,7 @@ fn second_to_last_weekday_of_month() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(7)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -929,7 +929,7 @@ fn every_3_hours_on_specific_day() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -948,7 +948,7 @@ fn every_15_min_for_6_occurrences() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -970,7 +970,7 @@ fn every_hour_and_a_half_for_4_occurrences() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -990,13 +990,13 @@ fn every_20_min_at_time_every_day() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(72)
-        .0;
+        .list;
     let dates_alt = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=MINUTELY;INTERVAL=20;BYHOUR=9,10,11,12,13,14,15,16"
         .parse::<RRuleSet>()
         .unwrap()
         .all(72)
-        .0;
+        .list;
 
     let mut expected = vec![];
     for day in 2..=4 {
@@ -1039,7 +1039,7 @@ fn week_day_start_monday_generated_days() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -1059,7 +1059,7 @@ fn week_day_start_sunday_generated_days() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[
@@ -1079,7 +1079,7 @@ fn invalid_date_is_ignored() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .0;
+        .list;
     common::check_occurrences(
         &dates,
         &[

--- a/rrule/src/tests/rrule.rs
+++ b/rrule/src/tests/rrule.rs
@@ -3842,7 +3842,7 @@ fn test_after_inclusive_hit() {
     let after = ymd_hms(2012, 2, 2, 9, 30, 0);
     let rrule = rrule.after(after);
 
-    assert_eq!(after, rrule.all(1).list[0]);
+    assert_eq!(after, rrule.all(1).dates[0]);
 }
 
 #[test]
@@ -3855,7 +3855,7 @@ fn test_after_inclusive_miss() {
     let rrule = rrule.after(after);
     let oracle = ymd_hms(2012, 2, 3, 9, 30, 0);
 
-    assert_eq!(oracle, rrule.all(1).list[0]);
+    assert_eq!(oracle, rrule.all(1).dates[0]);
 }
 
 #[test]

--- a/rrule/src/tests/rrule.rs
+++ b/rrule/src/tests/rrule.rs
@@ -3842,7 +3842,7 @@ fn test_after_inclusive_hit() {
     let after = ymd_hms(2012, 2, 2, 9, 30, 0);
     let rrule = rrule.after(after);
 
-    assert_eq!(after, rrule.all(1).0[0]);
+    assert_eq!(after, rrule.all(1).list[0]);
 }
 
 #[test]
@@ -3855,7 +3855,7 @@ fn test_after_inclusive_miss() {
     let rrule = rrule.after(after);
     let oracle = ymd_hms(2012, 2, 3, 9, 30, 0);
 
-    assert_eq!(oracle, rrule.all(1).0[0]);
+    assert_eq!(oracle, rrule.all(1).list[0]);
 }
 
 #[test]

--- a/rrule/src/tests/rruleset.rs
+++ b/rrule/src/tests/rruleset.rs
@@ -142,7 +142,7 @@ fn rrule_and_exdate_2() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .0;
+        .list;
     // This results in following set (minus exdate)
     // [
     //     2020-12-14T09:30:00CET,
@@ -277,7 +277,7 @@ fn after() {
         .exrule(exrule)
         .after(ymd_hms(2000, 9, 2, 9, 0, 0));
 
-    assert_eq!(set.all(1).0[0], ymd_hms(2007, 9, 2, 9, 0, 0),);
+    assert_eq!(set.all(1).list[0], ymd_hms(2007, 9, 2, 9, 0, 0),);
 }
 
 #[test]
@@ -315,7 +315,7 @@ fn between() {
         .before(ymd_hms(2010, 9, 2, 9, 0, 0));
 
     check_occurrences(
-        &set.all(u16::MAX).0,
+        &set.all(u16::MAX).list,
         &[
             "2007-09-02T09:00:00-00:00",
             "2008-09-02T09:00:00-00:00",

--- a/rrule/src/tests/rruleset.rs
+++ b/rrule/src/tests/rruleset.rs
@@ -142,7 +142,7 @@ fn rrule_and_exdate_2() {
         .parse::<RRuleSet>()
         .unwrap()
         .all(u16::MAX)
-        .list;
+        .dates;
     // This results in following set (minus exdate)
     // [
     //     2020-12-14T09:30:00CET,
@@ -277,7 +277,7 @@ fn after() {
         .exrule(exrule)
         .after(ymd_hms(2000, 9, 2, 9, 0, 0));
 
-    assert_eq!(set.all(1).list[0], ymd_hms(2007, 9, 2, 9, 0, 0),);
+    assert_eq!(set.all(1).dates[0], ymd_hms(2007, 9, 2, 9, 0, 0),);
 }
 
 #[test]
@@ -315,7 +315,7 @@ fn between() {
         .before(ymd_hms(2010, 9, 2, 9, 0, 0));
 
     check_occurrences(
-        &set.all(u16::MAX).list,
+        &set.all(u16::MAX).dates,
         &[
             "2007-09-02T09:00:00-00:00",
             "2008-09-02T09:00:00-00:00",

--- a/rrule/src/validator/validate_rrule.rs
+++ b/rrule/src/validator/validate_rrule.rs
@@ -588,16 +588,8 @@ mod tests {
     fn allows_until_with_compatible_timezone() {
         fn t(start_tz: Tz, until_tz: Tz) -> (DateTime, DateTime) {
             (
-                start_tz
-                    .ymd_opt(2020, 1, 1)
-                    .and_hms_opt(0, 0, 0)
-                    .unwrap()
-                    .into(),
-                until_tz
-                    .ymd_opt(2020, 1, 1)
-                    .and_hms_opt(0, 0, 0)
-                    .unwrap()
-                    .into(),
+                start_tz.ymd_opt(2020, 1, 1).and_hms_opt(0, 0, 0).unwrap(),
+                until_tz.ymd_opt(2020, 1, 1).and_hms_opt(0, 0, 0).unwrap(),
             )
         }
 
@@ -617,16 +609,8 @@ mod tests {
     fn rejects_until_with_incompatible_timezone() {
         fn t(start_tz: Tz, until_tz: Tz) -> (DateTime, DateTime) {
             (
-                start_tz
-                    .ymd_opt(2020, 1, 1)
-                    .and_hms_opt(0, 0, 0)
-                    .unwrap()
-                    .into(),
-                until_tz
-                    .ymd_opt(2020, 1, 1)
-                    .and_hms_opt(0, 0, 0)
-                    .unwrap()
-                    .into(),
+                start_tz.ymd_opt(2020, 1, 1).and_hms_opt(0, 0, 0).unwrap(),
+                until_tz.ymd_opt(2020, 1, 1).and_hms_opt(0, 0, 0).unwrap(),
             )
         }
 


### PR DESCRIPTION
Fix #80 
@fmeringdal is “limited” a correct wording? I still don't know its use case :)
Isn't “truncated” better?

Fix #64
I didn't test it, but don't forget to add your API token as `CARGO_REGISTRY_TOKEN` in the repo Settings > Secrets > Actions