### PR TITLE
PoC: Allow any TimeZone implementation

### DIFF
--- a/rrule-afl-fuzz/src/take_rrule.rs
+++ b/rrule-afl-fuzz/src/take_rrule.rs
@@ -8,7 +8,7 @@ use rrule::{Frequency, RRule, RRuleSet};
 /// This function uses the data to construct a deterministic input for [`RRuleSet`].
 /// This can also be used to reconstruct the [`RRuleSet`] from crashes in order to debug the code.
 #[must_use]
-pub fn take_rrule_from_data(mut data: &[u8]) -> Option<RRuleSet> {
+pub fn take_rrule_from_data(mut data: &[u8]) -> Option<RRuleSet<chrono_tz::Tz>> {
     // Byte uses: (always account for max used)
     // bytes => variable
     // ----------------

--- a/rrule-debugger/src/debug.rs
+++ b/rrule-debugger/src/debug.rs
@@ -11,7 +11,7 @@ pub fn run_debug_function() {
 }
 
 fn test_from_string() {
-    let rrule: RRuleSet = "DTSTART;TZID=America/New_York:19970519T090000\n\
+    let rrule: RRuleSet<_> = "DTSTART;TZID=America/New_York:19970519T090000\n\
     RRULE:FREQ=YEARLY;BYDAY=20MO"
         .parse()
         .unwrap();

--- a/rrule/examples/manual_iter.rs
+++ b/rrule/examples/manual_iter.rs
@@ -6,7 +6,7 @@ use chrono::Datelike;
 use rrule::RRuleSet;
 
 fn main() {
-    let rrule: RRuleSet = "DTSTART;TZID=America/New_York:20200902T130000\n\
+    let rrule: RRuleSet<_> = "DTSTART;TZID=America/New_York:20200902T130000\n\
         RRULE:FREQ=Weekly"
         .parse()
         .expect("The RRule is not valid");

--- a/rrule/src/core/datetime.rs
+++ b/rrule/src/core/datetime.rs
@@ -1,8 +1,6 @@
 use chrono::{Duration, NaiveTime};
 use chrono_tz::Tz;
 
-pub(crate) type DateTime = chrono::DateTime<Tz>;
-
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Time {
     pub hour: u8,
@@ -45,7 +43,7 @@ impl Time {
 /// Generates an iCalendar date-time string format with the prefix symbols.
 /// Like: `:19970714T173000Z` or `;TZID=America/New_York:19970714T133000`
 /// ref: <https://tools.ietf.org/html/rfc5545#section-3.3.5>
-pub(crate) fn datetime_to_ical_format(dt: &DateTime) -> String {
+pub(crate) fn datetime_to_ical_format(dt: &chrono::DateTime<chrono_tz::Tz>) -> String {
     let mut tz_prefix = String::new();
     let mut tz_postfix = String::new();
     let tz = dt.timezone();

--- a/rrule/src/core/mod.rs
+++ b/rrule/src/core/mod.rs
@@ -5,7 +5,7 @@ pub(crate) mod utils;
 
 pub use self::rrule::{Frequency, NWeekday, RRule};
 pub use self::rruleset::RRuleSet;
-pub(crate) use datetime::{DateTime, Time};
+pub(crate) use datetime::Time;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 /// An empty struct to keep the validated stage

--- a/rrule/src/core/rruleset.rs
+++ b/rrule/src/core/rruleset.rs
@@ -1,6 +1,5 @@
 use crate::core::datetime::datetime_to_ical_format;
 use crate::core::utils::{collect_or_error, collect_with_error};
-use crate::core::DateTime;
 use crate::parser::{ContentLine, Grammar};
 use crate::{RRule, RRuleError};
 #[cfg(feature = "serde")]
@@ -12,23 +11,26 @@ use std::str::FromStr;
 #[cfg_attr(feature = "serde", serde_as)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(DeserializeFromStr, SerializeDisplay))]
-pub struct RRuleSet {
+pub struct RRuleSet<TZ: chrono::TimeZone> {
     /// List of rrules.
-    pub(crate) rrule: Vec<RRule>,
+    pub(crate) rrule: Vec<RRule<TZ>>,
     /// List of rdates.
-    pub(crate) rdate: Vec<DateTime>,
+    pub(crate) rdate: Vec<chrono::DateTime<TZ>>,
     /// List of exules.
-    pub(crate) exrule: Vec<RRule>,
+    pub(crate) exrule: Vec<RRule<TZ>>,
     /// List of exdates.
-    pub(crate) exdate: Vec<DateTime>,
+    pub(crate) exdate: Vec<chrono::DateTime<TZ>>,
     /// The start datetime of the recurring event.
-    pub(crate) dt_start: DateTime,
+    pub(crate) dt_start: chrono::DateTime<TZ>,
 }
 
-impl RRuleSet {
+impl<TZ: chrono::TimeZone> RRuleSet<TZ> {
     /// Creates an empty [`RRuleSet`], starting from `ds_start`.
     #[must_use]
-    pub fn new(dt_start: DateTime) -> Self {
+    pub fn new(dt_start: chrono::DateTime<TZ>) -> Self
+    where
+        TZ: chrono::TimeZone,
+    {
         Self {
             dt_start,
             rrule: vec![],
@@ -40,87 +42,87 @@ impl RRuleSet {
 
     /// Adds a new rrule to the set.
     #[must_use]
-    pub fn rrule(mut self, rrule: RRule) -> Self {
+    pub fn rrule(mut self, rrule: RRule<TZ>) -> Self {
         self.rrule.push(rrule);
         self
     }
 
     /// Adds a new exrule to the set.
     #[must_use]
-    pub fn exrule(mut self, rrule: RRule) -> Self {
+    pub fn exrule(mut self, rrule: RRule<TZ>) -> Self {
         self.exrule.push(rrule);
         self
     }
 
     /// Adds a new rdate to the set.
     #[must_use]
-    pub fn rdate(mut self, rdate: DateTime) -> Self {
+    pub fn rdate(mut self, rdate: chrono::DateTime<TZ>) -> Self {
         self.rdate.push(rdate);
         self
     }
 
     /// Adds a new exdate to the set.
     #[must_use]
-    pub fn exdate(mut self, exdate: DateTime) -> Self {
+    pub fn exdate(mut self, exdate: chrono::DateTime<TZ>) -> Self {
         self.exdate.push(exdate);
         self
     }
 
     /// Sets the rrules of the set.
     #[must_use]
-    pub fn set_rrules(mut self, rrules: Vec<RRule>) -> Self {
+    pub fn set_rrules(mut self, rrules: Vec<RRule<TZ>>) -> Self {
         self.rrule = rrules;
         self
     }
 
     /// Sets the exrules of the set.
     #[must_use]
-    pub fn set_exrules(mut self, exrules: Vec<RRule>) -> Self {
+    pub fn set_exrules(mut self, exrules: Vec<RRule<TZ>>) -> Self {
         self.exrule = exrules;
         self
     }
 
     /// Sets the rdates of the set.
     #[must_use]
-    pub fn set_rdates(mut self, rdates: Vec<DateTime>) -> Self {
+    pub fn set_rdates(mut self, rdates: Vec<chrono::DateTime<TZ>>) -> Self {
         self.rdate = rdates;
         self
     }
 
     /// Set the exdates of the set.
     #[must_use]
-    pub fn set_exdates(mut self, exdates: Vec<DateTime>) -> Self {
+    pub fn set_exdates(mut self, exdates: Vec<chrono::DateTime<TZ>>) -> Self {
         self.exdate = exdates;
         self
     }
 
     /// Returns the rrules of the set.
     #[must_use]
-    pub fn get_rrule(&self) -> &Vec<RRule> {
+    pub fn get_rrule(&self) -> &Vec<RRule<TZ>> {
         &self.rrule
     }
 
     /// Returns the exrules of the set.
     #[must_use]
-    pub fn get_exrule(&self) -> &Vec<RRule> {
+    pub fn get_exrule(&self) -> &Vec<RRule<TZ>> {
         &self.exrule
     }
 
     /// Returns the rdates of the set.
     #[must_use]
-    pub fn get_rdate(&self) -> &Vec<DateTime> {
+    pub fn get_rdate(&self) -> &Vec<chrono::DateTime<TZ>> {
         &self.rdate
     }
 
     /// Returns the exdates of the set.
     #[must_use]
-    pub fn get_exdate(&self) -> &Vec<DateTime> {
+    pub fn get_exdate(&self) -> &Vec<chrono::DateTime<TZ>> {
         &self.exdate
     }
 
     /// Returns the start datetime of the recurring event.
     #[must_use]
-    pub fn get_dt_start(&self) -> &DateTime {
+    pub fn get_dt_start(&self) -> &chrono::DateTime<TZ> {
         &self.dt_start
     }
 
@@ -128,7 +130,7 @@ impl RRuleSet {
     ///
     /// Limit must be set in order to prevent infinite loops.
     /// The max limit is `65535`. If you need more please use `into_iter` directly.
-    pub fn all(self, limit: u16) -> Result<Vec<DateTime>, RRuleError> {
+    pub fn all(self, limit: u16) -> Result<Vec<chrono::DateTime<TZ>>, RRuleError> {
         collect_or_error(self.into_iter(), &None, &None, true, limit)
     }
 
@@ -140,7 +142,7 @@ impl RRuleSet {
     /// In case the iterator ended with an error, the error will be included,
     /// otherwise the second value of the return tuple will be `None`.
     #[must_use]
-    pub fn all_with_error(self, limit: u16) -> (Vec<DateTime>, Option<RRuleError>) {
+    pub fn all_with_error(self, limit: u16) -> (Vec<chrono::DateTime<TZ>>, Option<RRuleError>) {
         collect_with_error(self.into_iter(), &None, &None, true, limit)
     }
 
@@ -150,13 +152,13 @@ impl RRuleSet {
     /// With `inclusive == true`, if `before` itself is a recurrence, it will be returned.
     pub fn just_before(
         self,
-        before: DateTime,
+        before: chrono::DateTime<TZ>,
         inclusive: bool,
-    ) -> Result<Option<DateTime>, RRuleError> {
+    ) -> Result<Option<chrono::DateTime<TZ>>, RRuleError> {
         Ok(
             collect_or_error(self.into_iter(), &None, &Some(before), inclusive, u16::MAX)?
                 .last()
-                .copied(),
+                .cloned(),
         )
     }
 
@@ -170,10 +172,10 @@ impl RRuleSet {
     #[must_use]
     pub fn all_before_with_error(
         self,
-        before: DateTime,
+        before: chrono::DateTime<TZ>,
         inclusive: bool,
         limit: u16,
-    ) -> (Vec<DateTime>, Option<RRuleError>) {
+    ) -> (Vec<chrono::DateTime<TZ>>, Option<RRuleError>) {
         collect_with_error(self.into_iter(), &None, &Some(before), inclusive, limit)
     }
 
@@ -183,13 +185,13 @@ impl RRuleSet {
     /// With `inclusive == true`, if `after` itself is a recurrence, it will be returned.
     pub fn just_after(
         self,
-        after: DateTime,
+        after: chrono::DateTime<TZ>,
         inclusive: bool,
-    ) -> Result<Option<DateTime>, RRuleError> {
+    ) -> Result<Option<chrono::DateTime<TZ>>, RRuleError> {
         Ok(
             collect_or_error(self.into_iter(), &Some(after), &None, inclusive, 1)?
                 .first()
-                .copied(),
+                .cloned(),
         )
     }
 
@@ -203,10 +205,10 @@ impl RRuleSet {
     #[must_use]
     pub fn all_after_with_error(
         self,
-        after: DateTime,
+        after: chrono::DateTime<TZ>,
         inclusive: bool,
         limit: u16,
-    ) -> (Vec<DateTime>, Option<RRuleError>) {
+    ) -> (Vec<chrono::DateTime<TZ>>, Option<RRuleError>) {
         collect_with_error(self.into_iter(), &Some(after), &None, inclusive, limit)
     }
 
@@ -217,10 +219,10 @@ impl RRuleSet {
     /// list, if they are found in the recurrence set.
     pub fn all_between(
         self,
-        start: DateTime,
-        end: DateTime,
+        start: chrono::DateTime<TZ>,
+        end: chrono::DateTime<TZ>,
         inclusive: bool,
-    ) -> Result<Vec<DateTime>, RRuleError> {
+    ) -> Result<Vec<chrono::DateTime<TZ>>, RRuleError> {
         collect_or_error(
             self.into_iter(),
             &Some(start),
@@ -240,16 +242,16 @@ impl RRuleSet {
     #[must_use]
     pub fn all_between_with_error(
         self,
-        start: DateTime,
-        end: DateTime,
+        start: chrono::DateTime<TZ>,
+        end: chrono::DateTime<TZ>,
         inclusive: bool,
         limit: u16,
-    ) -> (Vec<DateTime>, Option<RRuleError>) {
+    ) -> (Vec<chrono::DateTime<TZ>>, Option<RRuleError>) {
         collect_with_error(self.into_iter(), &Some(start), &Some(end), inclusive, limit)
     }
 }
 
-impl FromStr for RRuleSet {
+impl FromStr for RRuleSet<chrono_tz::Tz> {
     type Err = RRuleError;
 
     /// Creates an [`RRuleSet`] from a string if input is valid.
@@ -270,7 +272,7 @@ impl FromStr for RRuleSet {
             |mut rrule_set, content_line| match content_line {
                 ContentLine::RRule(rrule) => {
                     let rrule = rrule.validate(start.datetime)?;
-                    Ok::<RRuleSet, RRuleError>(rrule_set.rrule(rrule))
+                    Ok::<RRuleSet<chrono_tz::Tz>, RRuleError>(rrule_set.rrule(rrule))
                 }
                 ContentLine::ExRule(rrule) => {
                     let rrule = rrule.validate(start.datetime)?;
@@ -293,7 +295,7 @@ impl FromStr for RRuleSet {
     }
 }
 
-impl Display for RRuleSet {
+impl Display for RRuleSet<chrono_tz::Tz> {
     /// Prints a valid set of iCalendar properties which can be used to create a new [`RRuleSet`] later.
     /// You may use the generated string to create a new iCalendar component, like VEVENT.
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/rrule/src/iter/iterinfo.rs
+++ b/rrule/src/iter/iterinfo.rs
@@ -5,22 +5,21 @@ use super::{
     utils::to_ordinal,
     yearinfo::{rebuild_year, YearInfo},
 };
-use crate::core::DateTime;
 use crate::{core::Time, Frequency, NWeekday, RRule, RRuleError};
 use chrono::{Datelike, TimeZone};
 
 #[derive(Debug, Clone)]
-pub(crate) struct IterInfo<'a> {
+pub(crate) struct IterInfo<'a, TZ: chrono::TimeZone> {
     year_info: Option<YearInfo>,
     month_info: Option<MonthInfo>,
     easter_mask: Option<Vec<isize>>,
-    rrule: &'a RRule,
+    rrule: &'a RRule<TZ>,
 }
 
-impl<'a> IterInfo<'a> {
+impl<'a, TZ: chrono::TimeZone> IterInfo<'a, TZ> {
     /// Only used to create a dummy instance of this because
     /// `into_iter` does not return an error.
-    pub(crate) fn new_no_rebuild(rrule: &'a RRule) -> Self {
+    pub(crate) fn new_no_rebuild(rrule: &'a RRule<TZ>) -> Self {
         Self {
             rrule,
             year_info: None,
@@ -29,7 +28,7 @@ impl<'a> IterInfo<'a> {
         }
     }
 
-    pub fn new(rrule: &'a RRule, dt_start: &DateTime) -> Result<Self, RRuleError> {
+    pub fn new(rrule: &'a RRule<TZ>, dt_start: &chrono::DateTime<TZ>) -> Result<Self, RRuleError> {
         let mut ii = Self {
             rrule,
             year_info: None,
@@ -259,7 +258,7 @@ impl<'a> IterInfo<'a> {
         }
     }
 
-    pub fn get_rrule(&self) -> &RRule {
+    pub fn get_rrule(&self) -> &RRule<TZ> {
         self.rrule
     }
 }

--- a/rrule/src/iter/monthinfo.rs
+++ b/rrule/src/iter/monthinfo.rs
@@ -9,13 +9,13 @@ pub(crate) struct MonthInfo {
     pub neg_weekday_mask: Vec<i8>,
 }
 
-pub(crate) fn rebuild_month(
+pub(crate) fn rebuild_month<TZ: chrono::TimeZone>(
     year: i32,
     month: u8,
     year_len: u16,
     month_range: &[u16],
     weekday_mask: &[u8],
-    rrule: &RRule,
+    rrule: &RRule<TZ>,
 ) -> Result<MonthInfo, RRuleError> {
     let mut result = MonthInfo {
         last_year: year,

--- a/rrule/src/iter/operation_errors.rs
+++ b/rrule/src/iter/operation_errors.rs
@@ -1,6 +1,6 @@
 use chrono::Duration;
 
-use crate::{core::DateTime, RRuleError};
+use crate::RRuleError;
 
 pub(crate) fn checked_mul_u32(v1: u32, v2: u32, hint: Option<&str>) -> Result<u32, RRuleError> {
     v1.checked_mul(v2).ok_or_else(|| match hint {
@@ -28,18 +28,18 @@ pub(crate) fn checked_add_u32(v1: u32, v2: u32, hint: Option<&str>) -> Result<u3
     })
 }
 
-pub(crate) fn checked_add_datetime_duration(
-    v1: DateTime,
+pub(crate) fn checked_add_datetime_duration<TZ: chrono::TimeZone>(
+    v1: chrono::DateTime<TZ>,
     v2: Duration,
     hint: Option<&str>,
-) -> Result<DateTime, RRuleError> {
-    v1.checked_add_signed(v2).ok_or_else(|| match hint {
+) -> Result<chrono::DateTime<TZ>, RRuleError> {
+    v1.clone().checked_add_signed(v2).ok_or_else(|| match hint {
         Some(hint) => RRuleError::new_iter_err(format!(
-            "Could not add Duration to DateTime, would overflow (`{} + {}`), {}.",
+            "Could not add Duration to DateTime, would overflow (`{:?} + {}`), {}.",
             v1, v2, hint
         )),
         None => RRuleError::new_iter_err(format!(
-            "Could not add Duration to DateTime, would overflow (`{} + {}`).",
+            "Could not add Duration to DateTime, would overflow (`{:?} + {}`).",
             v1, v2,
         )),
     })

--- a/rrule/src/iter/utils.rs
+++ b/rrule/src/iter/utils.rs
@@ -1,11 +1,10 @@
-use crate::core::DateTime;
 use chrono::{TimeZone, Utc};
 use chrono_tz::UTC;
 
 const DAY_SECS: i64 = 24 * 60 * 60;
 
 /// Converts number of days since unix epoch back to `DataTime`
-pub(crate) fn from_ordinal(ordinal: i64) -> DateTime {
+pub(crate) fn from_ordinal(ordinal: i64) -> chrono::DateTime<chrono_tz::Tz> {
     let timestamp = ordinal * DAY_SECS;
     UTC.timestamp(timestamp, 0)
 }

--- a/rrule/src/iter/yearinfo.rs
+++ b/rrule/src/iter/yearinfo.rs
@@ -66,7 +66,7 @@ fn base_year_masks(year_weekday: u8, year_len: u16) -> BaseMasks {
     clippy::cast_precision_loss,
     clippy::cast_sign_loss
 )]
-pub(crate) fn rebuild_year(year: i32, rrule: &RRule) -> YearInfo {
+pub(crate) fn rebuild_year<TZ: chrono::TimeZone>(year: i32, rrule: &RRule<TZ>) -> YearInfo {
     let first_year_day = Utc.ymd(year, 1, 1).and_hms(0, 0, 0);
 
     let year_len = get_year_len(year);

--- a/rrule/src/lib.rs
+++ b/rrule/src/lib.rs
@@ -24,7 +24,7 @@
 //! use chrono_tz::UTC;
 //! use rrule::{RRuleSet};
 //!
-//! let rrule: RRuleSet = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=3".parse().unwrap();
+//! let rrule: RRuleSet<_> = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=3".parse().unwrap();
 //!
 //! // All dates
 //! assert_eq!(
@@ -42,7 +42,7 @@
 //! # use chrono_tz::UTC;
 //! # use rrule::{RRuleSet};
 //! #
-//! let rrule: RRuleSet = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=3".parse().unwrap();
+//! let rrule: RRuleSet<_> = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=3".parse().unwrap();
 //! // Between two dates
 //! let after = UTC.ymd(2012, 2, 1).and_hms(10, 0, 0);
 //! let before = UTC.ymd(2012, 4, 1).and_hms(9, 0, 0);
@@ -68,12 +68,12 @@
 //! use rrule::{RRuleSet};
 //!
 //! // Parse a RRule string
-//! let rrule: RRuleSet = "DTSTART:20120201T093000Z\n\
+//! let rrule: RRuleSet<_> = "DTSTART:20120201T093000Z\n\
 //!    RRULE:FREQ=WEEKLY;INTERVAL=5;UNTIL=20130130T230000Z;BYDAY=MO,FR".parse().unwrap();
 //! assert_eq!(rrule.all(100).unwrap().len(), 21);
 //!
 //! // Parse a RRuleSet string
-//! let rrule_set: RRuleSet = "DTSTART:20120201T023000Z\n\
+//! let rrule_set: RRuleSet<_> = "DTSTART:20120201T023000Z\n\
 //!     RRULE:FREQ=MONTHLY;COUNT=5\n\
 //!     RDATE:20120701T023000Z,20120702T023000Z\n\
 //!     EXRULE:FREQ=MONTHLY;COUNT=2\n\

--- a/rrule/src/parser/content_line/date_content_line.rs
+++ b/rrule/src/parser/content_line/date_content_line.rs
@@ -1,11 +1,8 @@
 use std::{collections::HashMap, str::FromStr};
 
-use crate::{
-    core::DateTime,
-    parser::{
-        datetime::{datestring_to_date, parse_timezone},
-        ParseError,
-    },
+use crate::parser::{
+    datetime::{datestring_to_date, parse_timezone},
+    ParseError,
 };
 
 use super::{content_line_parts::ContentLineCaptures, parameters::parse_parameters};
@@ -29,7 +26,7 @@ impl FromStr for DateParameter {
     }
 }
 
-impl<'a> TryFrom<ContentLineCaptures<'a>> for Vec<DateTime> {
+impl<'a> TryFrom<ContentLineCaptures<'a>> for Vec<chrono::DateTime<chrono_tz::Tz>> {
     type Error = ParseError;
 
     fn try_from(value: ContentLineCaptures) -> Result<Self, Self::Error> {

--- a/rrule/src/parser/content_line/mod.rs
+++ b/rrule/src/parser/content_line/mod.rs
@@ -7,7 +7,6 @@ mod start_date_content_line;
 use std::fmt::Display;
 use std::str::FromStr;
 
-use crate::core::DateTime;
 use crate::RRule;
 use crate::Unvalidated;
 
@@ -17,11 +16,11 @@ pub(crate) use start_date_content_line::StartDateContentLine;
 use super::ParseError;
 
 #[derive(Debug, PartialEq)]
-pub(crate) enum ContentLine {
-    RRule(RRule<Unvalidated>),
-    ExRule(RRule<Unvalidated>),
-    ExDate(Vec<DateTime>),
-    RDate(Vec<DateTime>),
+pub(crate) enum ContentLine<TZ: chrono::TimeZone> {
+    RRule(RRule<TZ, Unvalidated>),
+    ExRule(RRule<TZ, Unvalidated>),
+    ExDate(Vec<chrono::DateTime<TZ>>),
+    RDate(Vec<chrono::DateTime<TZ>>),
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]

--- a/rrule/src/parser/content_line/start_date_content_line.rs
+++ b/rrule/src/parser/content_line/start_date_content_line.rs
@@ -1,27 +1,24 @@
 use std::collections::HashMap;
 
-use chrono_tz::{Tz, UTC};
+use chrono_tz::UTC;
 
 use super::{
     content_line_parts::ContentLineCaptures, date_content_line::DateParameter,
     parameters::parse_parameters,
 };
-use crate::{
-    core::DateTime,
-    parser::{
-        datetime::{datestring_to_date, parse_timezone},
-        ParseError,
-    },
+use crate::parser::{
+    datetime::{datestring_to_date, parse_timezone},
+    ParseError,
 };
 
 #[derive(Debug, PartialEq)]
-pub(crate) struct StartDateContentLine {
-    pub datetime: DateTime,
-    pub timezone: Option<Tz>,
+pub(crate) struct StartDateContentLine<TZ: chrono::TimeZone> {
+    pub datetime: chrono::DateTime<TZ>,
+    pub timezone: Option<TZ>,
     pub value: &'static str,
 }
 
-impl<'a> TryFrom<&ContentLineCaptures<'a>> for StartDateContentLine {
+impl<'a> TryFrom<&ContentLineCaptures<'a>> for StartDateContentLine<chrono_tz::Tz> {
     type Error = ParseError;
 
     fn try_from(content_line: &ContentLineCaptures) -> Result<Self, Self::Error> {

--- a/rrule/src/parser/datetime.rs
+++ b/rrule/src/parser/datetime.rs
@@ -4,7 +4,7 @@ use chrono::{NaiveDate, TimeZone, Weekday};
 use chrono_tz::{Tz, UTC};
 
 use super::{regex::ParsedDateString, ParseError};
-use crate::{core::DateTime, NWeekday};
+use crate::NWeekday;
 
 /// Attempts to convert a `str` to a `chrono_tz::Tz`.
 pub(crate) fn parse_timezone(tz: &str) -> Result<Tz, ParseError> {
@@ -16,9 +16,9 @@ pub(crate) fn parse_timezone(tz: &str) -> Result<Tz, ParseError> {
 /// argument will be ignored.
 pub(crate) fn datestring_to_date(
     dt: &str,
-    tz: Option<Tz>,
+    tz: Option<chrono_tz::Tz>,
     property: &str,
-) -> Result<DateTime, ParseError> {
+) -> Result<chrono::DateTime<Tz>, ParseError> {
     let ParsedDateString {
         year,
         month,
@@ -75,8 +75,8 @@ pub(crate) fn datestring_to_date(
                         Err(ParseError::DateTimeInLocalTimezoneIsAmbiguous {
                             value: dt.into(),
                             property: property.into(),
-                            date1: date1.to_rfc3339(),
-                            date2: date2.to_rfc3339(),
+                            date1: format!("{:?}", date1),
+                            date2: format!("{:?}", date2),
                         })
                     }
                 }?

--- a/rrule/src/parser/mod.rs
+++ b/rrule/src/parser/mod.rs
@@ -18,12 +18,12 @@ use self::content_line::{ContentLineCaptures, PropertyName, StartDateContentLine
 
 /// Grammar represents a well formatted rrule input.
 #[derive(Debug, PartialEq)]
-pub(crate) struct Grammar {
-    pub start: StartDateContentLine,
-    pub content_lines: Vec<ContentLine>,
+pub(crate) struct Grammar<TZ: chrono::TimeZone> {
+    pub start: StartDateContentLine<TZ>,
+    pub content_lines: Vec<ContentLine<TZ>>,
 }
 
-impl FromStr for Grammar {
+impl FromStr for Grammar<chrono_tz::Tz> {
     type Err = ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {

--- a/rrule/src/tests/common.rs
+++ b/rrule/src/tests/common.rs
@@ -17,10 +17,10 @@ pub fn ymd_hms(
     UTC.ymd(year, month, day).and_hms(hour, minute, second)
 }
 
-pub fn test_recurring_rrule(
-    rrule: RRule<Unvalidated>,
-    dt_start: DateTime<Tz>,
-    expected_dates: &[DateTime<Tz>],
+pub fn test_recurring_rrule<TZ: chrono::TimeZone>(
+    rrule: RRule<TZ, Unvalidated>,
+    dt_start: DateTime<TZ>,
+    expected_dates: &[DateTime<TZ>],
 ) {
     let rrule_set = rrule
         .build(dt_start)
@@ -46,7 +46,10 @@ pub fn test_recurring_rrule(
 }
 
 #[allow(clippy::needless_pass_by_value)]
-pub fn test_recurring_rrule_set(rrule_set: RRuleSet, expected_dates: &[DateTime<Tz>]) {
+pub fn test_recurring_rrule_set<TZ: chrono::TimeZone>(
+    rrule_set: RRuleSet<TZ>,
+    expected_dates: &[DateTime<Tz>],
+) {
     let res = rrule_set.all(100).unwrap();
 
     println!("Actual: {:?}", res);

--- a/rrule/src/tests/datetime.rs
+++ b/rrule/src/tests/datetime.rs
@@ -6,7 +6,7 @@ use crate::RRuleSet;
 fn monthly_on_31th() {
     let dates = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=MONTHLY;COUNT=10;BYMONTHDAY=31"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<_>>()
         .unwrap()
         .all(20)
         .unwrap();
@@ -33,7 +33,7 @@ fn monthly_on_31th() {
 fn monthly_on_31th_to_last() {
     let dates = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=MONTHLY;COUNT=10;BYMONTHDAY=-31"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<_>>()
         .unwrap()
         .all(20)
         .unwrap();

--- a/rrule/src/tests/daylight_saving.rs
+++ b/rrule/src/tests/daylight_saving.rs
@@ -2,7 +2,7 @@ use crate::{tests::common::check_occurrences, RRuleSet};
 
 #[test]
 fn daylight_savings_1() {
-    let rrule: RRuleSet =
+    let rrule: RRuleSet<_> =
         "DTSTART;TZID=America/Vancouver:20210301T022210\nRRULE:FREQ=DAILY;COUNT=30"
             .parse()
             .unwrap();
@@ -50,7 +50,7 @@ fn daylight_savings_1() {
 fn daylight_savings_2() {
     let dates = "DTSTART;TZID=Europe/Paris:20210214T093000\n\
         RRULE:FREQ=WEEKLY;UNTIL=20210508T083000Z;INTERVAL=2;BYDAY=MO;WKST=MO"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<_>>()
         .unwrap()
         .all(50)
         .unwrap();

--- a/rrule/src/tests/regression.rs
+++ b/rrule/src/tests/regression.rs
@@ -5,7 +5,7 @@ use crate::RRuleSet;
 fn issue_34() {
     let dates = "DTSTART;TZID=America/New_York:19970929T090000
 RRULE:FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=-2"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(7)
         .unwrap();
@@ -26,7 +26,7 @@ RRULE:FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=-2"
 #[test]
 #[ignore = "stick in an infinite loop in exrule calculation"]
 fn edge_case_1() {
-    let rrule_set: RRuleSet = "DTSTART;TZID=Europe/Berlin:20210101T000000;
+    let rrule_set: RRuleSet<chrono_tz::Tz> = "DTSTART;TZID=Europe/Berlin:20210101T000000;
 RRULE:FREQ=MONTHLY
 EXRULE:FREQ=MONTHLY"
         .parse()
@@ -38,7 +38,7 @@ EXRULE:FREQ=MONTHLY"
 #[test]
 #[ignore = "This time doesn't exist at all and some rruleset errors must be there: https://www.timeanddate.com/time/change/germany/berlin?year=1893"]
 fn edge_case_2() {
-    let rrule_set: RRuleSet = "DTSTART;TZID=Europe/Berlin:18930401T010000;\nRRULE:FREQ=DAILY"
+    let rrule_set: RRuleSet<chrono_tz::Tz> = "DTSTART;TZID=Europe/Berlin:18930401T010000;\nRRULE:FREQ=DAILY"
         .parse()
         .expect("The RRule is not valid");
 

--- a/rrule/src/tests/rfc_tests.rs
+++ b/rrule/src/tests/rfc_tests.rs
@@ -11,7 +11,7 @@ use crate::RRuleSet;
 fn daily_10_occurrences() {
     let dates = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=DAILY;COUNT=10"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(50)
         .unwrap();
@@ -39,7 +39,7 @@ fn daily_until_november() {
     // From september-november
     let dates = "DTSTART;TZID=America/New_York:19970920T090000\n\
         RRULE:FREQ=DAILY;UNTIL=19971103T000000Z"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(60)
         .unwrap();
@@ -103,7 +103,7 @@ fn daily_until_november() {
 fn every_other_day() {
     let dates = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=DAILY;INTERVAL=2"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(32)
         .unwrap();
@@ -151,7 +151,7 @@ fn every_other_day() {
 fn every_10_days_5_occurrences() {
     let dates = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=DAILY;INTERVAL=10;COUNT=5"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(50)
         .unwrap();
@@ -173,13 +173,13 @@ fn every_days_in_jan_for_3_years() {
     // To patterns that have same result
     let dates = "DTSTART;TZID=America/New_York:19980101T090000\n\
         RRULE:FREQ=YEARLY;UNTIL=20000131T140000Z;BYMONTH=1;BYDAY=SU,MO,TU,WE,TH,FR,SA"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(100)
         .unwrap();
     let dates_alt = "DTSTART;TZID=America/New_York:19980101T090000\n\
         RRULE:FREQ=DAILY;UNTIL=20000131T140000Z;BYMONTH=1"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(100)
         .unwrap();
@@ -200,7 +200,7 @@ fn every_days_in_jan_for_3_years() {
 fn weekly_10_occurrences() {
     let dates = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=WEEKLY;COUNT=10"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(50)
         .unwrap();
@@ -228,7 +228,7 @@ fn weekly_until_november() {
     // From september-november
     let dates = "DTSTART;TZID=America/New_York:19970923T090000\n\
         RRULE:FREQ=WEEKLY;UNTIL=19971105T000000Z"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(60)
         .unwrap();
@@ -255,7 +255,7 @@ fn weekly_until_november() {
 fn every_other_week() {
     let dates = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=WEEKLY;INTERVAL=2;WKST=SU"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(13)
         .unwrap();
@@ -284,13 +284,13 @@ fn every_other_week() {
 fn weekly_on_tue_and_thu_for_5_weeks() {
     let dates = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=WEEKLY;UNTIL=19971007T000000Z;WKST=SU;BYDAY=TU,TH"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(50)
         .unwrap();
     let dates_alt = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=WEEKLY;COUNT=10;WKST=SU;BYDAY=TU,TH"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(50)
         .unwrap();
@@ -316,7 +316,7 @@ fn weekly_on_tue_and_thu_for_5_weeks() {
 fn every_other_week_some_days_until_dec() {
     let dates = "DTSTART;TZID=America/New_York:19970901T090000\n\
         RRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=19971224T000000Z;WKST=SU;BYDAY=MO,WE,FR"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(50)
         .unwrap();
@@ -357,7 +357,7 @@ fn every_other_week_some_days_until_dec() {
 fn every_other_week_some_days_8_occurrences() {
     let dates = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=WEEKLY;INTERVAL=2;COUNT=8;WKST=SU;BYDAY=TU,TH"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(50)
         .unwrap();
@@ -383,7 +383,7 @@ fn every_other_week_some_days_8_occurrences() {
 fn monthly_on_first_friday_10_occurrences() {
     let dates = "DTSTART;TZID=America/New_York:19970905T090000\n\
         RRULE:FREQ=MONTHLY;COUNT=10;BYDAY=1FR"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(50)
         .unwrap();
@@ -409,7 +409,7 @@ fn monthly_on_first_friday_10_occurrences() {
 fn monthly_on_first_friday_until_dec() {
     let dates = "DTSTART;TZID=America/New_York:19970905T090000\n\
         RRULE:FREQ=MONTHLY;UNTIL=19971224T000000Z;BYDAY=1FR"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(50)
         .unwrap();
@@ -429,7 +429,7 @@ fn monthly_on_first_friday_until_dec() {
 fn every_other_month_on_first_and_last_sunday_10_occurrences() {
     let dates = "DTSTART;TZID=America/New_York:19970907T090000\n\
         RRULE:FREQ=MONTHLY;INTERVAL=2;COUNT=10;BYDAY=1SU,-1SU"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(50)
         .unwrap();
@@ -455,7 +455,7 @@ fn every_other_month_on_first_and_last_sunday_10_occurrences() {
 fn monthly_on_second_to_last_monday_for_6_months() {
     let dates = "DTSTART;TZID=America/New_York:19970922T090000\n\
         RRULE:FREQ=MONTHLY;COUNT=6;BYDAY=-2MO"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(50)
         .unwrap();
@@ -477,7 +477,7 @@ fn monthly_on_second_to_last_monday_for_6_months() {
 fn monthly_on_third_to_last_day_forever() {
     let dates = "DTSTART;TZID=America/New_York:19970928T090000\n\
         RRULE:FREQ=MONTHLY;BYMONTHDAY=-3"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(6)
         .unwrap();
@@ -499,7 +499,7 @@ fn monthly_on_third_to_last_day_forever() {
 fn monthly_on_2nd_and_15th_10_occurrences() {
     let dates = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=MONTHLY;COUNT=10;BYMONTHDAY=2,15"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(20)
         .unwrap();
@@ -525,7 +525,7 @@ fn monthly_on_2nd_and_15th_10_occurrences() {
 fn monthly_on_first_and_last_day_10_occurrences() {
     let dates = "DTSTART;TZID=America/New_York:19970930T090000\n\
         RRULE:FREQ=MONTHLY;COUNT=10;BYMONTHDAY=1,-1"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(20)
         .unwrap();
@@ -551,7 +551,7 @@ fn monthly_on_first_and_last_day_10_occurrences() {
 fn every_18_months_10th_to_15th_10_occurrences() {
     let dates = "DTSTART;TZID=America/New_York:19970910T090000\n\
         RRULE:FREQ=MONTHLY;INTERVAL=18;COUNT=10;BYMONTHDAY=10,11,12,13,14,15"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(20)
         .unwrap();
@@ -577,7 +577,7 @@ fn every_18_months_10th_to_15th_10_occurrences() {
 fn every_tuesday_every_other_month() {
     let dates = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=MONTHLY;INTERVAL=2;BYDAY=TU"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(18)
         .unwrap();
@@ -616,7 +616,7 @@ fn every_tuesday_every_other_month() {
 fn yearly_in_june_and_july_for_10_occurrences() {
     let dates = "DTSTART;TZID=America/New_York:19970610T090000\n\
         RRULE:FREQ=YEARLY;COUNT=10;BYMONTH=6,7"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(20)
         .unwrap();
@@ -642,7 +642,7 @@ fn yearly_in_june_and_july_for_10_occurrences() {
 fn every_other_year_on_jan_feb_and_march_for_10_occurrences() {
     let dates = "DTSTART;TZID=America/New_York:19970310T090000\n\
         RRULE:FREQ=YEARLY;INTERVAL=2;COUNT=10;BYMONTH=1,2,3"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(20)
         .unwrap();
@@ -668,7 +668,7 @@ fn every_other_year_on_jan_feb_and_march_for_10_occurrences() {
 fn every_third_year_on_1st_100th_and_200th_day_for_10_occurrences() {
     let dates = "DTSTART;TZID=America/New_York:19970101T090000\n\
         RRULE:FREQ=YEARLY;INTERVAL=3;COUNT=10;BYYEARDAY=1,100,200"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(20)
         .unwrap();
@@ -694,7 +694,7 @@ fn every_third_year_on_1st_100th_and_200th_day_for_10_occurrences() {
 fn every_20th_monday_of_year_forever() {
     let dates = "DTSTART;TZID=America/New_York:19970519T090000\n\
         RRULE:FREQ=YEARLY;BYDAY=20MO"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(3)
         .unwrap();
@@ -713,7 +713,7 @@ fn every_20th_monday_of_year_forever() {
 fn monday_of_week_20_forever() {
     let dates = "DTSTART;TZID=America/New_York:19970512T090000\n\
         RRULE:FREQ=YEARLY;BYWEEKNO=20;BYDAY=MO"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(3)
         .unwrap();
@@ -732,7 +732,7 @@ fn monday_of_week_20_forever() {
 fn every_thursday_in_march_forever() {
     let dates = "DTSTART;TZID=America/New_York:19970313T090000\n\
         RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=TH"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(11)
         .unwrap();
@@ -759,7 +759,7 @@ fn every_thursday_in_march_forever() {
 fn every_thursday_only_during_june_july_and_august_forever() {
     let dates = "DTSTART;TZID=America/New_York:19970605T090000\n\
         RRULE:FREQ=YEARLY;BYDAY=TH;BYMONTH=6,7,8"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(39)
         .unwrap();
@@ -815,7 +815,7 @@ fn every_friday_the_13th_forever() {
     let dates = "DTSTART;TZID=America/New_York:19970902T090000\n\
         EXDATE;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=MONTHLY;BYDAY=FR;BYMONTHDAY=13"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(5)
         .unwrap();
@@ -836,7 +836,7 @@ fn every_friday_the_13th_forever() {
 fn first_sat_follows_first_sunday_of_month_forever() {
     let dates = "DTSTART;TZID=America/New_York:19970913T090000\n\
         RRULE:FREQ=MONTHLY;BYDAY=SA;BYMONTHDAY=7,8,9,10,11,12,13"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(10)
         .unwrap();
@@ -863,7 +863,7 @@ fn first_sat_follows_first_sunday_of_month_forever() {
 fn every_4_years_us_presidential_election_day_forever() {
     let dates = "DTSTART;TZID=America/New_York:19961105T090000\n\
         RRULE:FREQ=YEARLY;INTERVAL=4;BYMONTH=11;BYDAY=TU;BYMONTHDAY=2,3,4,5,6,7,8"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(3)
         .unwrap();
@@ -883,7 +883,7 @@ fn every_4_years_us_presidential_election_day_forever() {
 fn every_third_instance_of_weekday_in_month_for_3_months() {
     let dates = "DTSTART;TZID=America/New_York:19970904T090000\n\
         RRULE:FREQ=MONTHLY;COUNT=3;BYDAY=TU,WE,TH;BYSETPOS=3"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(10)
         .unwrap();
@@ -902,7 +902,7 @@ fn every_third_instance_of_weekday_in_month_for_3_months() {
 fn second_to_last_weekday_of_month() {
     let dates = "DTSTART;TZID=America/New_York:19970929T090000\n\
         RRULE:FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=-2"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(7)
         .unwrap();
@@ -926,7 +926,7 @@ fn every_3_hours_on_specific_day() {
     // https://www.rfc-editor.org/errata/eid3883
     let dates = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=HOURLY;INTERVAL=3;UNTIL=19970902T210000Z"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(10)
         .unwrap();
@@ -945,7 +945,7 @@ fn every_3_hours_on_specific_day() {
 fn every_15_min_for_6_occurrences() {
     let dates = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=MINUTELY;INTERVAL=15;COUNT=6"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(10)
         .unwrap();
@@ -967,7 +967,7 @@ fn every_15_min_for_6_occurrences() {
 fn every_hour_and_a_half_for_4_occurrences() {
     let dates = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=MINUTELY;INTERVAL=90;COUNT=4"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(10)
         .unwrap();
@@ -987,13 +987,13 @@ fn every_hour_and_a_half_for_4_occurrences() {
 fn every_20_min_at_time_every_day() {
     let dates = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=DAILY;BYHOUR=9,10,11,12,13,14,15,16;BYMINUTE=0,20,40"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(72)
         .unwrap();
     let dates_alt = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=MINUTELY;INTERVAL=20;BYHOUR=9,10,11,12,13,14,15,16"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(72)
         .unwrap();
@@ -1036,7 +1036,7 @@ fn every_20_min_at_time_every_day() {
 fn week_day_start_monday_generated_days() {
     let dates = "DTSTART;TZID=America/New_York:19970805T090000\n\
         RRULE:FREQ=WEEKLY;INTERVAL=2;COUNT=4;BYDAY=TU,SU;WKST=MO"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(10)
         .unwrap();
@@ -1056,7 +1056,7 @@ fn week_day_start_monday_generated_days() {
 fn week_day_start_sunday_generated_days() {
     let dates = "DTSTART;TZID=America/New_York:19970805T090000\n\
         RRULE:FREQ=WEEKLY;INTERVAL=2;COUNT=4;BYDAY=TU,SU;WKST=SU"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(10)
         .unwrap();
@@ -1076,7 +1076,7 @@ fn week_day_start_sunday_generated_days() {
 fn invalid_date_is_ignored() {
     let dates = "DTSTART;TZID=America/New_York:20070115T090000\n\
         RRULE:FREQ=MONTHLY;BYMONTHDAY=15,30;COUNT=5"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(10)
         .unwrap();

--- a/rrule/src/tests/rrule.rs
+++ b/rrule/src/tests/rrule.rs
@@ -3651,7 +3651,7 @@ fn test_timezones_weekly() {
 
 #[test]
 fn test_before_inclusive_hit() {
-    let rrule: RRuleSet = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=3"
+    let rrule: RRuleSet<chrono_tz::Tz> = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=3"
         .parse()
         .unwrap();
 
@@ -3663,7 +3663,7 @@ fn test_before_inclusive_hit() {
 
 #[test]
 fn test_before_inclusive_miss() {
-    let rrule: RRuleSet = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=3"
+    let rrule: RRuleSet<chrono_tz::Tz> = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=3"
         .parse()
         .unwrap();
 
@@ -3676,7 +3676,7 @@ fn test_before_inclusive_miss() {
 
 #[test]
 fn test_after_inclusive_hit() {
-    let rrule: RRuleSet = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=3"
+    let rrule: RRuleSet<chrono_tz::Tz> = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=3"
         .parse()
         .unwrap();
 
@@ -3688,7 +3688,7 @@ fn test_after_inclusive_hit() {
 
 #[test]
 fn test_after_inclusive_miss() {
-    let rrule: RRuleSet = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=3"
+    let rrule: RRuleSet<chrono_tz::Tz> = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=3"
         .parse()
         .unwrap();
 
@@ -3701,7 +3701,7 @@ fn test_after_inclusive_miss() {
 
 #[test]
 fn test_between_inclusive_both_miss() {
-    let rrule: RRuleSet = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=5"
+    let rrule: RRuleSet<chrono_tz::Tz> = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=5"
         .parse()
         .unwrap();
 
@@ -3715,7 +3715,7 @@ fn test_between_inclusive_both_miss() {
 
 #[test]
 fn test_between_inclusive_lower_miss() {
-    let rrule: RRuleSet = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=5"
+    let rrule: RRuleSet<chrono_tz::Tz> = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=5"
         .parse()
         .unwrap();
 
@@ -3732,7 +3732,7 @@ fn test_between_inclusive_lower_miss() {
 
 #[test]
 fn test_between_inclusive_upper_miss() {
-    let rrule: RRuleSet = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=5"
+    let rrule: RRuleSet<chrono_tz::Tz> = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=5"
         .parse()
         .unwrap();
 
@@ -3749,7 +3749,7 @@ fn test_between_inclusive_upper_miss() {
 
 #[test]
 fn test_between_inclusive_both_hit() {
-    let rrule: RRuleSet = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=5"
+    let rrule: RRuleSet<chrono_tz::Tz> = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=5"
         .parse()
         .unwrap();
 

--- a/rrule/src/tests/rruleset.rs
+++ b/rrule/src/tests/rruleset.rs
@@ -138,7 +138,7 @@ fn rrule_and_exdate_2() {
     let dates = "DTSTART;TZID=Europe/Paris:20201214T093000\n\
         RRULE:FREQ=WEEKLY;UNTIL=20210308T083000Z;INTERVAL=2;BYDAY=MO;WKST=MO\n\
         EXDATE;TZID=Europe/Paris:20201228T093000,20210125T093000,20210208T093000"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<chrono_tz::Tz>>()
         .unwrap()
         .all(50)
         .unwrap();

--- a/rrule/src/validator/check_limits.rs
+++ b/rrule/src/validator/check_limits.rs
@@ -1,4 +1,3 @@
-use crate::core::DateTime;
 use crate::{validator::ValidationError, RRule, Unvalidated};
 
 /// Maximum value of `option.interval` when frequency is yearly.
@@ -48,9 +47,9 @@ pub(crate) static FREQ_SECONDLY_INTERVAL_MAX: u16 = 50_000;
 /// When `no-validation-limits` feature is set this function will always return `Ok`.
 /// See README.md for more info.
 #[cfg(not(feature = "no-validation-limits"))]
-pub(crate) fn check_limits(
-    rrule: &RRule<Unvalidated>,
-    dt_start: &DateTime,
+pub(crate) fn check_limits<TZ: chrono::TimeZone>(
+    rrule: &RRule<TZ, Unvalidated>,
+    dt_start: &chrono::DateTime<TZ>,
 ) -> Result<(), ValidationError> {
     use crate::{validator::YEAR_RANGE, Frequency};
     use chrono::Datelike;


### PR DESCRIPTION
Make the TimeZone parametrised in as many places as possible. This allows using other TimeZone implementations for most of the logic. Most notably, this allows using `chrono::Local`.

Using `chrono::Local` makes it much easier  to construct TimeZone instances from parsed `VTIMEZONE` components.

Some notes:

- There's a few new `.clone()` calls. This is because `chrono_tz::Tz` implements `Copy`, but other `TimeZone` implementation do not.
- For error messages, we cannot use `to_string()`, since `TimeZone` does not imply `Display`. The implementations in the `chrono` package are the most obvious offenders here. I've used `Debug` instead, which `TimeZone` DOES require.

This is a proof of concept (which I wrote on a long train trip). Tests pass, but this probably warrants some extra discussion.

Fixes: https://github.com/fmeringdal/rust-rrule/issues/24