### PR TITLE
PoC: Allow any TimeZone implementation

### DIFF
--- a/rrule-afl-fuzz/src/take_rrule.rs
+++ b/rrule-afl-fuzz/src/take_rrule.rs
@@ -8,7 +8,7 @@ use rrule::{Frequency, RRule, RRuleSet};
 /// This function uses the data to construct a deterministic input for [`RRuleSet`].
 /// This can also be used to reconstruct the [`RRuleSet`] from crashes in order to debug the code.
 #[must_use]
-pub fn take_rrule_from_data(mut data: &[u8]) -> Option<RRuleSet> {
+pub fn take_rrule_from_data(mut data: &[u8]) -> Option<RRuleSet<rrule::Tz>> {
     // Byte uses: (always account for max used)
     // bytes => variable
     // ----------------

--- a/rrule-debugger/src/debug.rs
+++ b/rrule-debugger/src/debug.rs
@@ -10,7 +10,7 @@ pub fn run_debug_function() {
 }
 
 fn test_from_string() {
-    let rrule: RRuleSet = "DTSTART;TZID=America/New_York:19970519T090000\n\
+    let rrule: RRuleSet<_> = "DTSTART;TZID=America/New_York:19970519T090000\n\
     RRULE:FREQ=YEARLY;BYDAY=20MO"
         .parse()
         .unwrap();

--- a/rrule/examples/manual_iter.rs
+++ b/rrule/examples/manual_iter.rs
@@ -6,7 +6,7 @@ use chrono::Datelike;
 use rrule::RRuleSet;
 
 fn main() {
-    let rrule: RRuleSet = "DTSTART;TZID=America/New_York:20200902T130000\n\
+    let rrule: RRuleSet<_> = "DTSTART;TZID=America/New_York:20200902T130000\n\
         RRULE:FREQ=Weekly"
         .parse()
         .expect("The RRule is not valid");

--- a/rrule/src/core/datetime.rs
+++ b/rrule/src/core/datetime.rs
@@ -1,7 +1,6 @@
-use super::timezone::Tz;
 use chrono::{Datelike, Duration, NaiveTime, Timelike};
 
-pub(crate) type DateTime = chrono::DateTime<Tz>;
+use crate::Tz;
 
 pub(crate) fn duration_from_midnight(time: NaiveTime) -> Duration {
     Duration::hours(i64::from(time.hour()))
@@ -9,30 +8,30 @@ pub(crate) fn duration_from_midnight(time: NaiveTime) -> Duration {
         + Duration::seconds(i64::from(time.second()))
 }
 
-pub(crate) fn get_month(dt: &DateTime) -> u8 {
+pub(crate) fn get_month<TZ: chrono::TimeZone>(dt: &chrono::DateTime<TZ>) -> u8 {
     u8::try_from(dt.month()).expect("month is between 1-12 which is covered by u8")
 }
 
-pub(crate) fn get_day(dt: &DateTime) -> i8 {
+pub(crate) fn get_day<TZ: chrono::TimeZone>(dt: &chrono::DateTime<TZ>) -> i8 {
     i8::try_from(dt.day()).expect("day is between 1-31 which is covered by i8")
 }
 
-pub(crate) fn get_hour(dt: &DateTime) -> u8 {
+pub(crate) fn get_hour<TZ: chrono::TimeZone>(dt: &chrono::DateTime<TZ>) -> u8 {
     u8::try_from(dt.hour()).expect("hour is between 0-23 which is covered by u8")
 }
 
-pub(crate) fn get_minute(dt: &DateTime) -> u8 {
+pub(crate) fn get_minute<TZ: chrono::TimeZone>(dt: &chrono::DateTime<TZ>) -> u8 {
     u8::try_from(dt.minute()).expect("minute is between 0-59 which is covered by u8")
 }
 
-pub(crate) fn get_second(dt: &DateTime) -> u8 {
+pub(crate) fn get_second<TZ: chrono::TimeZone>(dt: &chrono::DateTime<TZ>) -> u8 {
     u8::try_from(dt.second()).expect("second is between 0-59 which is covered by u8")
 }
 
 /// Generates an iCalendar date-time string format with the prefix symbols.
 /// Like: `:19970714T173000Z` or `;TZID=America/New_York:19970714T133000`
 /// ref: <https://tools.ietf.org/html/rfc5545#section-3.3.5>
-pub(crate) fn datetime_to_ical_format(dt: &DateTime) -> String {
+pub(crate) fn datetime_to_ical_format(dt: &chrono::DateTime<Tz>) -> String {
     let mut tz_prefix = String::new();
     let mut tz_postfix = String::new();
     let tz = dt.timezone();

--- a/rrule/src/core/mod.rs
+++ b/rrule/src/core/mod.rs
@@ -8,7 +8,7 @@ pub(crate) mod utils;
 pub use self::rrule::{Frequency, NWeekday, RRule};
 pub use self::rruleset::{RRuleResult, RRuleSet};
 pub(crate) use datetime::{
-    duration_from_midnight, get_day, get_hour, get_minute, get_month, get_second, DateTime,
+    duration_from_midnight, get_day, get_hour, get_minute, get_month, get_second,
 };
 pub use timezone::Tz;
 

--- a/rrule/src/iter/counter_date.rs
+++ b/rrule/src/iter/counter_date.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use chrono::{Datelike, TimeZone, Timelike, Utc, Weekday};
 
-use crate::{core::DateTime, Frequency, RRule, RRuleError};
+use crate::{Frequency, RRule, RRuleError};
 
 use super::{
     checks,
@@ -33,7 +33,11 @@ impl DateTimeIter {
     /// is higher than daily (e.g. hourly) where this function might return a date with the
     /// same day, but the iterator already knows that the current day cannot
     /// be part of the result.
-    pub fn increment(&mut self, rrule: &RRule, increment_day: bool) -> Result<(), RRuleError> {
+    pub fn increment<TZ: chrono::TimeZone>(
+        &mut self,
+        rrule: &RRule<TZ>,
+        increment_day: bool,
+    ) -> Result<(), RRuleError> {
         let RRule {
             interval,
             week_start,
@@ -299,8 +303,8 @@ impl DateTimeIter {
     }
 }
 
-impl From<&DateTime> for DateTimeIter {
-    fn from(dt: &DateTime) -> Self {
+impl<TZ: chrono::TimeZone> From<&chrono::DateTime<TZ>> for DateTimeIter {
+    fn from(dt: &chrono::DateTime<TZ>) -> Self {
         Self {
             year: dt.year(),
             month: dt.month(),

--- a/rrule/src/iter/iterinfo.rs
+++ b/rrule/src/iter/iterinfo.rs
@@ -2,20 +2,20 @@ use super::counter_date::DateTimeIter;
 #[cfg(feature = "by-easter")]
 use super::easter::easter;
 use super::{monthinfo::MonthInfo, yearinfo::YearInfo};
-use crate::core::{get_month, DateTime};
+use crate::core::get_month;
 use crate::{Frequency, NWeekday, RRule};
 use chrono::{Datelike, NaiveTime, TimeZone};
 
 #[derive(Debug, Clone)]
-pub(crate) struct IterInfo<'a> {
+pub(crate) struct IterInfo<'a, TZ: chrono::TimeZone> {
     year_info: YearInfo,
     month_info: Option<MonthInfo>,
     easter_mask: Option<Vec<i32>>,
-    rrule: &'a RRule,
+    rrule: &'a RRule<TZ>,
 }
 
-impl<'a> IterInfo<'a> {
-    pub fn new(rrule: &'a RRule, dt_start: &DateTime) -> Self {
+impl<'a, TZ: chrono::TimeZone> IterInfo<'a, TZ> {
+    pub fn new(rrule: &'a RRule<TZ>, dt_start: &chrono::DateTime<TZ>) -> Self {
         let year = dt_start.year();
         let month = get_month(dt_start);
 
@@ -257,7 +257,7 @@ impl<'a> IterInfo<'a> {
         }
     }
 
-    pub fn rrule(&self) -> &RRule {
+    pub fn rrule(&self) -> &RRule<TZ> {
         self.rrule
     }
 }

--- a/rrule/src/iter/monthinfo.rs
+++ b/rrule/src/iter/monthinfo.rs
@@ -9,7 +9,7 @@ pub(crate) struct MonthInfo {
 }
 
 impl MonthInfo {
-    pub fn new(year_info: &YearInfo, month: u8, rrule: &RRule) -> Self {
+    pub fn new<TZ: chrono::TimeZone>(year_info: &YearInfo, month: u8, rrule: &RRule<TZ>) -> Self {
         let neg_weekday_mask = Self::get_neg_weekday_mask(year_info, month, rrule);
         Self {
             last_year: year_info.year,
@@ -18,7 +18,11 @@ impl MonthInfo {
         }
     }
 
-    fn get_neg_weekday_mask(year_info: &YearInfo, month: u8, rrule: &RRule) -> Vec<u8> {
+    fn get_neg_weekday_mask<TZ: chrono::TimeZone>(
+        year_info: &YearInfo,
+        month: u8,
+        rrule: &RRule<TZ>,
+    ) -> Vec<u8> {
         let YearInfo {
             year_len,
             month_range,

--- a/rrule/src/iter/pos_list.rs
+++ b/rrule/src/iter/pos_list.rs
@@ -1,14 +1,13 @@
 use super::utils::{add_time_to_date, from_ordinal, pymod};
-use crate::core::{DateTime, Tz};
 use chrono::NaiveTime;
 
-pub(crate) fn build_pos_list(
+pub(crate) fn build_pos_list<TZ: chrono::TimeZone>(
     by_set_pos: &[i32],
     dayset: &[usize],
     timeset: &[NaiveTime],
     year_ordinal: i64,
-    tz: Tz,
-) -> Vec<DateTime> {
+    tz: TZ,
+) -> Vec<chrono::DateTime<TZ>> {
     let mut pos_list = vec![];
 
     if timeset.is_empty() {

--- a/rrule/src/iter/utils.rs
+++ b/rrule/src/iter/utils.rs
@@ -1,6 +1,6 @@
 use std::ops;
 
-use crate::core::{duration_from_midnight, DateTime, Tz};
+use crate::core::{duration_from_midnight, Tz};
 use chrono::{Date, NaiveTime, TimeZone, Utc};
 
 const UTC: Tz = Tz::UTC;
@@ -8,7 +8,7 @@ const UTC: Tz = Tz::UTC;
 const DAY_SECS: i64 = 24 * 60 * 60;
 
 /// Converts number of days since unix epoch back to `DataTime`
-pub(crate) fn from_ordinal(ordinal: i64) -> DateTime {
+pub(crate) fn from_ordinal(ordinal: i64) -> chrono::DateTime<crate::Tz> {
     let timestamp = ordinal * DAY_SECS;
     UTC.timestamp(timestamp, 0)
 }
@@ -73,7 +73,10 @@ where
     }
 }
 
-pub(crate) fn add_time_to_date(date: Date<Tz>, time: NaiveTime) -> Option<DateTime> {
+pub(crate) fn add_time_to_date<TZ: chrono::TimeZone>(
+    date: Date<TZ>,
+    time: NaiveTime,
+) -> Option<chrono::DateTime<TZ>> {
     if let Some(dt) = date.and_time(time) {
         return Some(dt);
     }

--- a/rrule/src/iter/yearinfo.rs
+++ b/rrule/src/iter/yearinfo.rs
@@ -54,7 +54,7 @@ pub(crate) struct YearInfo {
 }
 
 impl YearInfo {
-    pub fn new(year: i32, rrule: &RRule) -> Self {
+    pub fn new<TZ: chrono::TimeZone>(year: i32, rrule: &RRule<TZ>) -> Self {
         let first_year_day = Utc.ymd(year, 1, 1).and_hms(0, 0, 0);
 
         let year_len = get_year_len(year);

--- a/rrule/src/lib.rs
+++ b/rrule/src/lib.rs
@@ -49,7 +49,7 @@
 //! use chrono::{DateTime, TimeZone};
 //! use rrule::{RRuleSet, Tz};
 //!
-//! let rrule: RRuleSet = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=3".parse().unwrap();
+//! let rrule: RRuleSet<_> = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=3".parse().unwrap();
 //! let result = rrule.all(100);
 //!
 //! // All dates
@@ -67,7 +67,7 @@
 //!  use chrono::{DateTime, TimeZone};
 //!  use rrule::{RRuleSet, Tz};
 //!
-//! let rrule: RRuleSet = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=3".parse().unwrap();
+//! let rrule: RRuleSet<_> = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=3".parse().unwrap();
 //!
 //! // Between two dates
 //! let after = Tz::UTC.ymd(2012, 2, 1).and_hms(10, 0, 0);

--- a/rrule/src/parser/content_line/date_content_line.rs
+++ b/rrule/src/parser/content_line/date_content_line.rs
@@ -1,11 +1,8 @@
 use std::{collections::HashMap, str::FromStr};
 
-use crate::{
-    core::DateTime,
-    parser::{
-        datetime::{datestring_to_date, parse_timezone},
-        ParseError,
-    },
+use crate::parser::{
+    datetime::{datestring_to_date, parse_timezone},
+    ParseError,
 };
 
 use super::{content_line_parts::ContentLineCaptures, parameters::parse_parameters};
@@ -29,7 +26,7 @@ impl FromStr for DateParameter {
     }
 }
 
-impl<'a> TryFrom<ContentLineCaptures<'a>> for Vec<DateTime> {
+impl<'a> TryFrom<ContentLineCaptures<'a>> for Vec<chrono::DateTime<crate::Tz>> {
     type Error = ParseError;
 
     fn try_from(value: ContentLineCaptures) -> Result<Self, Self::Error> {

--- a/rrule/src/parser/content_line/mod.rs
+++ b/rrule/src/parser/content_line/mod.rs
@@ -7,7 +7,6 @@ mod start_date_content_line;
 use std::fmt::Display;
 use std::str::FromStr;
 
-use crate::core::DateTime;
 use crate::RRule;
 use crate::Unvalidated;
 
@@ -17,11 +16,11 @@ pub(crate) use start_date_content_line::StartDateContentLine;
 use super::ParseError;
 
 #[derive(Debug, PartialEq)]
-pub(crate) enum ContentLine {
-    RRule(RRule<Unvalidated>),
-    ExRule(RRule<Unvalidated>),
-    ExDate(Vec<DateTime>),
-    RDate(Vec<DateTime>),
+pub(crate) enum ContentLine<TZ: chrono::TimeZone> {
+    RRule(RRule<TZ, Unvalidated>),
+    ExRule(RRule<TZ, Unvalidated>),
+    ExDate(Vec<chrono::DateTime<TZ>>),
+    RDate(Vec<chrono::DateTime<TZ>>),
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]

--- a/rrule/src/parser/content_line/rule_content_line.rs
+++ b/rrule/src/parser/content_line/rule_content_line.rs
@@ -62,7 +62,7 @@ impl FromStr for RRuleProperty {
     }
 }
 
-impl<'a> TryFrom<ContentLineCaptures<'a>> for RRule<Unvalidated> {
+impl<'a> TryFrom<ContentLineCaptures<'a>> for RRule<crate::Tz, Unvalidated> {
     type Error = ParseError;
 
     fn try_from(value: ContentLineCaptures) -> Result<Self, Self::Error> {
@@ -84,7 +84,7 @@ impl<'a> TryFrom<ContentLineCaptures<'a>> for RRule<Unvalidated> {
 #[allow(clippy::too_many_lines)]
 fn props_to_rrule(
     props: &HashMap<RRuleProperty, String>,
-) -> Result<RRule<Unvalidated>, ParseError> {
+) -> Result<RRule<crate::Tz, Unvalidated>, ParseError> {
     let freq = props
         .get(&RRuleProperty::Freq)
         .map(|freq| Frequency::from_str(freq))

--- a/rrule/src/parser/content_line/start_date_content_line.rs
+++ b/rrule/src/parser/content_line/start_date_content_line.rs
@@ -5,7 +5,7 @@ use super::{
     parameters::parse_parameters,
 };
 use crate::{
-    core::{DateTime, Tz},
+    core::Tz,
     parser::{
         datetime::{datestring_to_date, parse_timezone},
         ParseError,
@@ -15,13 +15,13 @@ use crate::{
 const UTC: Tz = Tz::UTC;
 
 #[derive(Debug, PartialEq)]
-pub(crate) struct StartDateContentLine {
-    pub datetime: DateTime,
-    pub timezone: Option<Tz>,
+pub(crate) struct StartDateContentLine<TZ: chrono::TimeZone> {
+    pub datetime: chrono::DateTime<TZ>,
+    pub timezone: Option<TZ>,
     pub value: &'static str,
 }
 
-impl<'a> TryFrom<&ContentLineCaptures<'a>> for StartDateContentLine {
+impl<'a> TryFrom<&ContentLineCaptures<'a>> for StartDateContentLine<crate::Tz> {
     type Error = ParseError;
 
     fn try_from(content_line: &ContentLineCaptures) -> Result<Self, Self::Error> {

--- a/rrule/src/parser/datetime.rs
+++ b/rrule/src/parser/datetime.rs
@@ -1,10 +1,7 @@
 use std::str::FromStr;
 
 use super::{regex::ParsedDateString, ParseError};
-use crate::{
-    core::{DateTime, Tz},
-    NWeekday,
-};
+use crate::{core::Tz, NWeekday};
 use chrono::{NaiveDate, TimeZone, Weekday};
 
 /// Attempts to convert a `str` to a `chrono_tz::Tz`.
@@ -19,9 +16,9 @@ pub(crate) fn parse_timezone(tz: &str) -> Result<Tz, ParseError> {
 /// argument will be ignored.
 pub(crate) fn datestring_to_date(
     dt: &str,
-    tz: Option<Tz>,
+    tz: Option<crate::Tz>,
     property: &str,
-) -> Result<DateTime, ParseError> {
+) -> Result<chrono::DateTime<crate::Tz>, ParseError> {
     let ParsedDateString {
         year,
         month,
@@ -78,8 +75,8 @@ pub(crate) fn datestring_to_date(
                         Err(ParseError::DateTimeInLocalTimezoneIsAmbiguous {
                             value: dt.into(),
                             property: property.into(),
-                            date1: date1.to_rfc3339(),
-                            date2: date2.to_rfc3339(),
+                            date1: format!("{:?}", date1),
+                            date2: format!("{:?}", date2),
                         })
                     }
                 }?

--- a/rrule/src/parser/mod.rs
+++ b/rrule/src/parser/mod.rs
@@ -18,12 +18,12 @@ use self::content_line::{PropertyName, StartDateContentLine};
 
 /// Grammar represents a well formatted rrule input.
 #[derive(Debug, PartialEq)]
-pub(crate) struct Grammar {
-    pub start: StartDateContentLine,
-    pub content_lines: Vec<ContentLine>,
+pub(crate) struct Grammar<TZ: chrono::TimeZone> {
+    pub start: StartDateContentLine<TZ>,
+    pub content_lines: Vec<ContentLine<TZ>>,
 }
 
-impl FromStr for Grammar {
+impl FromStr for Grammar<crate::Tz> {
     type Err = ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -39,7 +39,7 @@ impl FromStr for Grammar {
             .map(StartDateContentLine::try_from)
             .ok_or(ParseError::MissingStartDate)??;
 
-        let mut content_lines = vec![];
+        let mut content_lines: Vec<ContentLine<crate::Tz>> = vec![];
 
         for parts in content_lines_parts {
             let line = match parts.property_name {

--- a/rrule/src/tests/common.rs
+++ b/rrule/src/tests/common.rs
@@ -16,11 +16,11 @@ pub fn ymd_hms(
     Tz::UTC.ymd(year, month, day).and_hms(hour, minute, second)
 }
 
-pub fn test_recurring_rrule(
-    rrule: RRule<Unvalidated>,
+pub fn test_recurring_rrule<TZ: chrono::TimeZone>(
+    rrule: RRule<TZ, Unvalidated>,
     limited: bool,
-    dt_start: DateTime<Tz>,
-    expected_dates: &[DateTime<Tz>],
+    dt_start: DateTime<TZ>,
+    expected_dates: &[DateTime<TZ>],
 ) {
     let rrule_set = rrule
         .build(dt_start)
@@ -50,7 +50,10 @@ pub fn test_recurring_rrule(
 }
 
 #[allow(clippy::needless_pass_by_value)]
-pub fn test_recurring_rrule_set(rrule_set: RRuleSet, expected_dates: &[DateTime<Tz>]) {
+pub fn test_recurring_rrule_set<TZ: chrono::TimeZone>(
+    rrule_set: RRuleSet<TZ>,
+    expected_dates: &[chrono::DateTime<Tz>],
+) {
     let res = rrule_set.all(u16::MAX).dates;
 
     println!("Actual: {:?}", res);

--- a/rrule/src/tests/datetime.rs
+++ b/rrule/src/tests/datetime.rs
@@ -6,7 +6,7 @@ use crate::RRuleSet;
 fn monthly_on_31th() {
     let dates = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=MONTHLY;COUNT=10;BYMONTHDAY=31"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<_>>()
         .unwrap()
         .all(u16::MAX)
         .dates;
@@ -33,7 +33,7 @@ fn monthly_on_31th() {
 fn monthly_on_31th_to_last() {
     let dates = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=MONTHLY;COUNT=10;BYMONTHDAY=-31"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<_>>()
         .unwrap()
         .all(u16::MAX)
         .dates;

--- a/rrule/src/tests/daylight_saving.rs
+++ b/rrule/src/tests/daylight_saving.rs
@@ -2,7 +2,7 @@ use crate::{tests::common::check_occurrences, RRuleSet};
 
 #[test]
 fn daylight_savings_1() {
-    let rrule: RRuleSet =
+    let rrule: RRuleSet<_> =
         "DTSTART;TZID=America/Vancouver:20210301T022210\nRRULE:FREQ=DAILY;COUNT=30"
             .parse()
             .unwrap();
@@ -49,7 +49,7 @@ fn daylight_savings_1() {
 fn daylight_savings_2() {
     let dates = "DTSTART;TZID=Europe/Paris:20210214T093000\n\
         RRULE:FREQ=WEEKLY;UNTIL=20210508T083000Z;INTERVAL=2;BYDAY=MO;WKST=MO"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<_>>()
         .unwrap()
         .all(u16::MAX)
         .dates;

--- a/rrule/src/tests/regression.rs
+++ b/rrule/src/tests/regression.rs
@@ -5,7 +5,7 @@ use crate::RRuleSet;
 fn issue_34() {
     let dates = "DTSTART;TZID=America/New_York:19970929T090000
 RRULE:FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=-2"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(7)
         .dates;
@@ -26,7 +26,7 @@ RRULE:FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=-2"
 #[test]
 fn issue_49() {
     let rrule_set = "DTSTART:20211214T091500\nEXDATE:20211228T091500,20220104T091500\nRRULE:FREQ=WEEKLY;UNTIL=20220906T091500;INTERVAL=1;BYDAY=TU;WKST=MO"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<_>>()
         .expect("The RRule is not valid");
 
     let res = rrule_set.all(1).dates;
@@ -39,7 +39,7 @@ fn issue_49() {
 #[test]
 fn issue_61() {
     let rrule_set = "DTSTART;TZID=Europe/Berlin:18930401T010000\nRRULE:FREQ=DAILY"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<_>>()
         .expect("The RRule is not valid");
 
     let res = rrule_set.all(10).dates;

--- a/rrule/src/tests/rfc_tests.rs
+++ b/rrule/src/tests/rfc_tests.rs
@@ -11,7 +11,7 @@ use crate::RRuleSet;
 fn daily_10_occurrences() {
     let dates = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=DAILY;COUNT=10"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(u16::MAX)
         .dates;
@@ -39,7 +39,7 @@ fn daily_until_november() {
     // From september-november
     let dates = "DTSTART;TZID=America/New_York:19970920T090000\n\
         RRULE:FREQ=DAILY;UNTIL=19971103T000000Z"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(u16::MAX)
         .dates;
@@ -103,7 +103,7 @@ fn daily_until_november() {
 fn every_other_day() {
     let dates = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=DAILY;INTERVAL=2"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(32)
         .dates;
@@ -151,7 +151,7 @@ fn every_other_day() {
 fn every_10_days_5_occurrences() {
     let dates = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=DAILY;INTERVAL=10;COUNT=5"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(u16::MAX)
         .dates;
@@ -173,13 +173,13 @@ fn every_days_in_jan_for_3_years() {
     // To patterns that have same result
     let dates = "DTSTART;TZID=America/New_York:19980101T090000\n\
         RRULE:FREQ=YEARLY;UNTIL=20000131T140000Z;BYMONTH=1;BYDAY=SU,MO,TU,WE,TH,FR,SA"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(100)
         .dates;
     let dates_alt = "DTSTART;TZID=America/New_York:19980101T090000\n\
         RRULE:FREQ=DAILY;UNTIL=20000131T140000Z;BYMONTH=1"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(100)
         .dates;
@@ -200,7 +200,7 @@ fn every_days_in_jan_for_3_years() {
 fn weekly_10_occurrences() {
     let dates = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=WEEKLY;COUNT=10"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(u16::MAX)
         .dates;
@@ -228,7 +228,7 @@ fn weekly_until_november() {
     // From september-november
     let dates = "DTSTART;TZID=America/New_York:19970923T090000\n\
         RRULE:FREQ=WEEKLY;UNTIL=19971105T000000Z"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(u16::MAX)
         .dates;
@@ -255,7 +255,7 @@ fn weekly_until_november() {
 fn every_other_week() {
     let dates = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=WEEKLY;INTERVAL=2;WKST=SU"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(13)
         .dates;
@@ -284,13 +284,13 @@ fn every_other_week() {
 fn weekly_on_tue_and_thu_for_5_weeks() {
     let dates = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=WEEKLY;UNTIL=19971007T000000Z;WKST=SU;BYDAY=TU,TH"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(u16::MAX)
         .dates;
     let dates_alt = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=WEEKLY;COUNT=10;WKST=SU;BYDAY=TU,TH"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(u16::MAX)
         .dates;
@@ -316,7 +316,7 @@ fn weekly_on_tue_and_thu_for_5_weeks() {
 fn every_other_week_some_days_until_dec() {
     let dates = "DTSTART;TZID=America/New_York:19970901T090000\n\
         RRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=19971224T000000Z;WKST=SU;BYDAY=MO,WE,FR"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(u16::MAX)
         .dates;
@@ -357,7 +357,7 @@ fn every_other_week_some_days_until_dec() {
 fn every_other_week_some_days_8_occurrences() {
     let dates = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=WEEKLY;INTERVAL=2;COUNT=8;WKST=SU;BYDAY=TU,TH"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(u16::MAX)
         .dates;
@@ -383,7 +383,7 @@ fn every_other_week_some_days_8_occurrences() {
 fn monthly_on_first_friday_10_occurrences() {
     let dates = "DTSTART;TZID=America/New_York:19970905T090000\n\
         RRULE:FREQ=MONTHLY;COUNT=10;BYDAY=1FR"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(u16::MAX)
         .dates;
@@ -409,7 +409,7 @@ fn monthly_on_first_friday_10_occurrences() {
 fn monthly_on_first_friday_until_dec() {
     let dates = "DTSTART;TZID=America/New_York:19970905T090000\n\
         RRULE:FREQ=MONTHLY;UNTIL=19971224T000000Z;BYDAY=1FR"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(u16::MAX)
         .dates;
@@ -429,7 +429,7 @@ fn monthly_on_first_friday_until_dec() {
 fn every_other_month_on_first_and_last_sunday_10_occurrences() {
     let dates = "DTSTART;TZID=America/New_York:19970907T090000\n\
         RRULE:FREQ=MONTHLY;INTERVAL=2;COUNT=10;BYDAY=1SU,-1SU"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(u16::MAX)
         .dates;
@@ -455,7 +455,7 @@ fn every_other_month_on_first_and_last_sunday_10_occurrences() {
 fn monthly_on_second_to_last_monday_for_6_months() {
     let dates = "DTSTART;TZID=America/New_York:19970922T090000\n\
         RRULE:FREQ=MONTHLY;COUNT=6;BYDAY=-2MO"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(u16::MAX)
         .dates;
@@ -477,7 +477,7 @@ fn monthly_on_second_to_last_monday_for_6_months() {
 fn monthly_on_third_to_last_day_forever() {
     let dates = "DTSTART;TZID=America/New_York:19970928T090000\n\
         RRULE:FREQ=MONTHLY;BYMONTHDAY=-3"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(6)
         .dates;
@@ -499,7 +499,7 @@ fn monthly_on_third_to_last_day_forever() {
 fn monthly_on_2nd_and_15th_10_occurrences() {
     let dates = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=MONTHLY;COUNT=10;BYMONTHDAY=2,15"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(u16::MAX)
         .dates;
@@ -525,7 +525,7 @@ fn monthly_on_2nd_and_15th_10_occurrences() {
 fn monthly_on_first_and_last_day_10_occurrences() {
     let dates = "DTSTART;TZID=America/New_York:19970930T090000\n\
         RRULE:FREQ=MONTHLY;COUNT=10;BYMONTHDAY=1,-1"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(u16::MAX)
         .dates;
@@ -551,7 +551,7 @@ fn monthly_on_first_and_last_day_10_occurrences() {
 fn every_18_months_10th_to_15th_10_occurrences() {
     let dates = "DTSTART;TZID=America/New_York:19970910T090000\n\
         RRULE:FREQ=MONTHLY;INTERVAL=18;COUNT=10;BYMONTHDAY=10,11,12,13,14,15"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(u16::MAX)
         .dates;
@@ -577,7 +577,7 @@ fn every_18_months_10th_to_15th_10_occurrences() {
 fn every_tuesday_every_other_month() {
     let dates = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=MONTHLY;INTERVAL=2;BYDAY=TU"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(18)
         .dates;
@@ -616,7 +616,7 @@ fn every_tuesday_every_other_month() {
 fn yearly_in_june_and_july_for_10_occurrences() {
     let dates = "DTSTART;TZID=America/New_York:19970610T090000\n\
         RRULE:FREQ=YEARLY;COUNT=10;BYMONTH=6,7"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(u16::MAX)
         .dates;
@@ -642,7 +642,7 @@ fn yearly_in_june_and_july_for_10_occurrences() {
 fn every_other_year_on_jan_feb_and_march_for_10_occurrences() {
     let dates = "DTSTART;TZID=America/New_York:19970310T090000\n\
         RRULE:FREQ=YEARLY;INTERVAL=2;COUNT=10;BYMONTH=1,2,3"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(u16::MAX)
         .dates;
@@ -668,7 +668,7 @@ fn every_other_year_on_jan_feb_and_march_for_10_occurrences() {
 fn every_third_year_on_1st_100th_and_200th_day_for_10_occurrences() {
     let dates = "DTSTART;TZID=America/New_York:19970101T090000\n\
         RRULE:FREQ=YEARLY;INTERVAL=3;COUNT=10;BYYEARDAY=1,100,200"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(u16::MAX)
         .dates;
@@ -694,7 +694,7 @@ fn every_third_year_on_1st_100th_and_200th_day_for_10_occurrences() {
 fn every_20th_monday_of_year_forever() {
     let dates = "DTSTART;TZID=America/New_York:19970519T090000\n\
         RRULE:FREQ=YEARLY;BYDAY=20MO"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(3)
         .dates;
@@ -713,7 +713,7 @@ fn every_20th_monday_of_year_forever() {
 fn monday_of_week_20_forever() {
     let dates = "DTSTART;TZID=America/New_York:19970512T090000\n\
         RRULE:FREQ=YEARLY;BYWEEKNO=20;BYDAY=MO"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(3)
         .dates;
@@ -732,7 +732,7 @@ fn monday_of_week_20_forever() {
 fn every_thursday_in_march_forever() {
     let dates = "DTSTART;TZID=America/New_York:19970313T090000\n\
         RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=TH"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(11)
         .dates;
@@ -759,7 +759,7 @@ fn every_thursday_in_march_forever() {
 fn every_thursday_only_during_june_july_and_august_forever() {
     let dates = "DTSTART;TZID=America/New_York:19970605T090000\n\
         RRULE:FREQ=YEARLY;BYDAY=TH;BYMONTH=6,7,8"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(39)
         .dates;
@@ -815,7 +815,7 @@ fn every_friday_the_13th_forever() {
     let dates = "DTSTART;TZID=America/New_York:19970902T090000\n\
         EXDATE;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=MONTHLY;BYDAY=FR;BYMONTHDAY=13"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(5)
         .dates;
@@ -836,7 +836,7 @@ fn every_friday_the_13th_forever() {
 fn first_sat_follows_first_sunday_of_month_forever() {
     let dates = "DTSTART;TZID=America/New_York:19970913T090000\n\
         RRULE:FREQ=MONTHLY;BYDAY=SA;BYMONTHDAY=7,8,9,10,11,12,13"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(10)
         .dates;
@@ -863,7 +863,7 @@ fn first_sat_follows_first_sunday_of_month_forever() {
 fn every_4_years_us_presidential_election_day_forever() {
     let dates = "DTSTART;TZID=America/New_York:19961105T090000\n\
         RRULE:FREQ=YEARLY;INTERVAL=4;BYMONTH=11;BYDAY=TU;BYMONTHDAY=2,3,4,5,6,7,8"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(3)
         .dates;
@@ -883,7 +883,7 @@ fn every_4_years_us_presidential_election_day_forever() {
 fn every_third_instance_of_weekday_in_month_for_3_months() {
     let dates = "DTSTART;TZID=America/New_York:19970904T090000\n\
         RRULE:FREQ=MONTHLY;COUNT=3;BYDAY=TU,WE,TH;BYSETPOS=3"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(u16::MAX)
         .dates;
@@ -902,7 +902,7 @@ fn every_third_instance_of_weekday_in_month_for_3_months() {
 fn second_to_last_weekday_of_month() {
     let dates = "DTSTART;TZID=America/New_York:19970929T090000\n\
         RRULE:FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=-2"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(7)
         .dates;
@@ -926,7 +926,7 @@ fn every_3_hours_on_specific_day() {
     // https://www.rfc-editor.org/errata/eid3883
     let dates = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=HOURLY;INTERVAL=3;UNTIL=19970902T210000Z"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(u16::MAX)
         .dates;
@@ -945,7 +945,7 @@ fn every_3_hours_on_specific_day() {
 fn every_15_min_for_6_occurrences() {
     let dates = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=MINUTELY;INTERVAL=15;COUNT=6"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(u16::MAX)
         .dates;
@@ -967,7 +967,7 @@ fn every_15_min_for_6_occurrences() {
 fn every_hour_and_a_half_for_4_occurrences() {
     let dates = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=MINUTELY;INTERVAL=90;COUNT=4"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(u16::MAX)
         .dates;
@@ -987,13 +987,13 @@ fn every_hour_and_a_half_for_4_occurrences() {
 fn every_20_min_at_time_every_day() {
     let dates = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=DAILY;BYHOUR=9,10,11,12,13,14,15,16;BYMINUTE=0,20,40"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(72)
         .dates;
     let dates_alt = "DTSTART;TZID=America/New_York:19970902T090000\n\
         RRULE:FREQ=MINUTELY;INTERVAL=20;BYHOUR=9,10,11,12,13,14,15,16"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(72)
         .dates;
@@ -1036,7 +1036,7 @@ fn every_20_min_at_time_every_day() {
 fn week_day_start_monday_generated_days() {
     let dates = "DTSTART;TZID=America/New_York:19970805T090000\n\
         RRULE:FREQ=WEEKLY;INTERVAL=2;COUNT=4;BYDAY=TU,SU;WKST=MO"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(u16::MAX)
         .dates;
@@ -1056,7 +1056,7 @@ fn week_day_start_monday_generated_days() {
 fn week_day_start_sunday_generated_days() {
     let dates = "DTSTART;TZID=America/New_York:19970805T090000\n\
         RRULE:FREQ=WEEKLY;INTERVAL=2;COUNT=4;BYDAY=TU,SU;WKST=SU"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(u16::MAX)
         .dates;
@@ -1076,7 +1076,7 @@ fn week_day_start_sunday_generated_days() {
 fn invalid_date_is_ignored() {
     let dates = "DTSTART;TZID=America/New_York:20070115T090000\n\
         RRULE:FREQ=MONTHLY;BYMONTHDAY=15,30;COUNT=5"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(u16::MAX)
         .dates;

--- a/rrule/src/tests/rrule.rs
+++ b/rrule/src/tests/rrule.rs
@@ -3810,7 +3810,7 @@ fn test_timezones_weekly() {
 
 #[test]
 fn test_before_inclusive_hit() {
-    let rrule: RRuleSet = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=3"
+    let rrule: RRuleSet<_> = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=3"
         .parse()
         .unwrap();
 
@@ -3822,7 +3822,7 @@ fn test_before_inclusive_hit() {
 
 #[test]
 fn test_before_inclusive_miss() {
-    let rrule: RRuleSet = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=3"
+    let rrule: RRuleSet<crate::Tz> = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=3"
         .parse()
         .unwrap();
 
@@ -3835,7 +3835,7 @@ fn test_before_inclusive_miss() {
 
 #[test]
 fn test_after_inclusive_hit() {
-    let rrule: RRuleSet = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=3"
+    let rrule: RRuleSet<crate::Tz> = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=3"
         .parse()
         .unwrap();
 
@@ -3847,7 +3847,7 @@ fn test_after_inclusive_hit() {
 
 #[test]
 fn test_after_inclusive_miss() {
-    let rrule: RRuleSet = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=3"
+    let rrule: RRuleSet<crate::Tz> = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=3"
         .parse()
         .unwrap();
 
@@ -3860,7 +3860,7 @@ fn test_after_inclusive_miss() {
 
 #[test]
 fn test_between_inclusive_both_miss() {
-    let rrule: RRuleSet = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=5"
+    let rrule: RRuleSet<crate::Tz> = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=5"
         .parse()
         .unwrap();
 
@@ -3875,7 +3875,7 @@ fn test_between_inclusive_both_miss() {
 
 #[test]
 fn test_between_inclusive_lower_miss() {
-    let rrule: RRuleSet = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=5"
+    let rrule: RRuleSet<crate::Tz> = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=5"
         .parse()
         .unwrap();
 
@@ -3890,7 +3890,7 @@ fn test_between_inclusive_lower_miss() {
 
 #[test]
 fn test_between_inclusive_upper_miss() {
-    let rrule: RRuleSet = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=5"
+    let rrule: RRuleSet<crate::Tz> = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=5"
         .parse()
         .unwrap();
 
@@ -3905,7 +3905,7 @@ fn test_between_inclusive_upper_miss() {
 
 #[test]
 fn test_between_inclusive_both_hit() {
-    let rrule: RRuleSet = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=5"
+    let rrule: RRuleSet<crate::Tz> = "DTSTART:20120201T093000Z\nRRULE:FREQ=DAILY;COUNT=5"
         .parse()
         .unwrap();
 

--- a/rrule/src/tests/rruleset.rs
+++ b/rrule/src/tests/rruleset.rs
@@ -139,7 +139,7 @@ fn rrule_and_exdate_2() {
     let dates = "DTSTART;TZID=Europe/Paris:20201214T093000\n\
         RRULE:FREQ=WEEKLY;UNTIL=20210308T083000Z;INTERVAL=2;BYDAY=MO;WKST=MO\n\
         EXDATE;TZID=Europe/Paris:20201228T093000,20210125T093000,20210208T093000"
-        .parse::<RRuleSet>()
+        .parse::<RRuleSet<crate::Tz>>()
         .unwrap()
         .all(u16::MAX)
         .dates;

--- a/rrule/src/tests/serde.rs
+++ b/rrule/src/tests/serde.rs
@@ -24,7 +24,7 @@ fn serialize_deserialize_json_to_and_from_rrule_set() {
     #[derive(orig_serde::Deserialize, orig_serde::Serialize, PartialEq, Eq, Debug)]
     #[serde(crate = "orig_serde")]
     struct RruleTest {
-        rrule: RRuleSet,
+        rrule: RRuleSet<crate::Tz>,
     }
 
     let test_cases = [


### PR DESCRIPTION
Make the TimeZone parametrised in as many places as possible. This allows using any TimeZone implementations for most of the logic. Most notably, this allows using `chrono::Local`.

Using `chrono::Local` makes it much easier  to construct TimeZone instances from parsed `VTIMEZONE` components and to interoperate with other crates.

Some notes:

- There's a few new `.clone()` calls. This is because `chrono_tz::Tz` implements `Copy`, but other `TimeZone` implementation do not. In reality, these values were already being copied before anyway, but this was done implicitly.
- For error messages, `to_string()` cannot be used, since `TimeZone` does not implement `Display`. The implementations in the `chrono` package are the most obvious offenders here. `Debug` is now used instead for error messages.
- The `validate_until` validation is no longer called. It assumes that all `RRules` use the `rrule::Tz` TimeZone implementation. I don't see an obvious way to fix it, and this is still a pending item.

This is a proof of concept (which I wrote on a long train trip). Tests pass, but this probably warrants some extra discussion.

Fixes: https://github.com/fmeringdal/rust-rrule/issues/24