### PR TITLE
Add `RRuleSet::set_from_string` to support loading rules without DTSTART

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MSRV is bumped to `v1.74.0` from `v1.64.0`
 - Make `ParseError` and `ValidationError` public
 - `EXRULE`s are now correctly added as exrules on the `RRuleSet` when parsed from a string, instead of being incorrectly added as an rrule.
+- Add a `RRuleSet::set_from_string` method to support loading rules without DTSTART. This is useful particularly when working with the Google Calendar API.
 
 ## 0.11.0 (2023-07-18)
 

--- a/rrule/src/core/rruleset.rs
+++ b/rrule/src/core/rruleset.rs
@@ -245,7 +245,7 @@ impl RRuleSet {
         )
     }
 
-    /// Load an [`RRuleSet`] from a string.
+    /// Set the [`RRuleSet`] properties from a string. If a DTSTART is found, it will be used as the start datetime.
     pub fn set_from_string(mut self, s: &str) -> Result<Self, RRuleError> {
         let Grammar {
             start,


### PR DESCRIPTION
This PR adds a new method to RRuleSet called `set_from_string` which is similar to the `FromStr` implementation but allows passing rules without a DTSTART line. This is useful in particular when working with Google's API, which provides the rrule without the DTSTART:

![image](https://github.com/fmeringdal/rust-rrule/assets/39950/567b47ba-d97f-42ae-8b92-9a051d490216)

As it stands today, because the entire parser module is private, you would need to format a DTSTART line and add it to the rrule (only for it to be parsed again).

I pulled out the common logic in `from_str` to a private `set_from_content_lines` method to avoid duplication.