### PR TITLE
Fix invalid occurrences for BYDAY rrules

### DIFF
--- a/rrule/src/iter/counter_date.rs
+++ b/rrule/src/iter/counter_date.rs
@@ -76,7 +76,8 @@ impl DateTimeIter {
                 self.month = 12;
                 year_div -= 1;
             }
-            self.increment_yearly(year_div)?;
+            self.year += i32::from(year_div);
+            checks::check_year_range(self.year)?;
         }
         Ok(())
     }

--- a/rrule/src/tests/rrule.rs
+++ b/rrule/src/tests/rrule.rs
@@ -1170,6 +1170,27 @@ fn monthly_by_nweekday_large() {
 }
 
 #[test]
+fn issue_104() {
+    let rrule = RRule {
+        freq: Frequency::Monthly,
+        interval: 2,
+        count: Some(3),
+        by_weekday: vec![NWeekday::Nth(-1, Weekday::Mon)],
+        ..Default::default()
+    };
+    test_recurring_rrule(
+        rrule,
+        true,
+        ymd_hms(2023, 10, 30, 9, 0, 0),
+        &[
+            ymd_hms(2023, 10, 30, 9, 0, 0),
+            ymd_hms(2023, 12, 25, 9, 0, 0),
+            ymd_hms(2024, 2, 26, 9, 0, 0),
+        ],
+    );
+}
+
+#[test]
 fn monthly_by_month_and_weekday() {
     let rrule = RRule {
         freq: Frequency::Monthly,


### PR DESCRIPTION
Fixes #104. When incrementing a monthly RRULE, the end of month check breaks recurrences if the new counter date falls outside of the month's date range. Instead of using `increment_yearly`, just update the `year` to avoid the call to `fix_day`.