### PR TITLE
fix: render weekdays as valid rrule strings

### DIFF
--- a/rrule/src/core/rrule.rs
+++ b/rrule/src/core/rrule.rs
@@ -656,7 +656,7 @@ impl<S> Display for RRule<S> {
 
         // Monday is the default, no need to expose it.
         if self.week_start != Weekday::Mon {
-            res.push(format!("WKST={}", &self.week_start));
+            res.push(format!("WKST={}", weekday_to_str(self.week_start)));
         }
 
         if !self.by_set_pos.is_empty() {

--- a/rrule/src/tests/regression.rs
+++ b/rrule/src/tests/regression.rs
@@ -1,7 +1,7 @@
 use chrono::Month;
 
 use crate::tests::common;
-use crate::{Frequency, RRule, RRuleSet};
+use crate::{Frequency, RRule, RRuleSet, Unvalidated};
 
 #[test]
 fn issue_34() {
@@ -59,4 +59,14 @@ fn issue_97() {
         rrule.to_string(),
         "FREQ=YEARLY;BYMONTH=12;BYMONTHDAY=24,25,26"
     );
+}
+
+#[test]
+fn issue_111() {
+    let rrule = "RRULE:FREQ=WEEKLY;INTERVAL=1;BYDAY=TU;WKST=SU"
+        .parse::<RRule<Unvalidated>>();
+
+        // Convert to string...
+    let rrule_str = format!("{}", rrule.unwrap());
+    assert!(rrule_str.contains("WKST=SU"));
 }

--- a/rrule/src/tests/regression.rs
+++ b/rrule/src/tests/regression.rs
@@ -63,10 +63,9 @@ fn issue_97() {
 
 #[test]
 fn issue_111() {
-    let rrule = "RRULE:FREQ=WEEKLY;INTERVAL=1;BYDAY=TU;WKST=SU"
-        .parse::<RRule<Unvalidated>>();
+    let rrule = "RRULE:FREQ=WEEKLY;INTERVAL=1;BYDAY=TU;WKST=SU".parse::<RRule<Unvalidated>>();
 
-        // Convert to string...
+    // Convert to string...
     let rrule_str = format!("{}", rrule.unwrap());
     assert!(rrule_str.contains("WKST=SU"));
 }


### PR DESCRIPTION
Previously, weekdays would've been rendered by their built-in name (e.g. `Sun`)