### PR TITLE
replace regex with custom parsers

### DIFF
--- a/rrule/Cargo.toml
+++ b/rrule/Cargo.toml
@@ -15,9 +15,7 @@ edition.workspace = true
 [dependencies]
 chrono = "0.4.19"
 chrono-tz = "0.9.0"
-lazy_static = "1.4.0"
 log = "0.4.16"
-regex = { version = "1.5.5", default-features = false, features = ["perf", "std"] }
 clap = { version = "4.1.9", optional = true, features = ["derive"] }
 thiserror = "1.0.30"
 serde_with = { version = "3.8.1", optional = true }

--- a/rrule/src/parser/content_line/content_line_parts.rs
+++ b/rrule/src/parser/content_line/content_line_parts.rs
@@ -1,4 +1,4 @@
-use crate::parser::{regex::get_property_name, ParseError};
+use crate::parser::{parsers::get_property_name, ParseError};
 
 use super::PropertyName;
 

--- a/rrule/src/parser/datetime.rs
+++ b/rrule/src/parser/datetime.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use super::{regex::ParsedDateString, ParseError};
+use super::{parsers::ParsedDateString, ParseError};
 use crate::{core::Tz, NWeekday};
 use chrono::{NaiveDate, TimeZone, Weekday};
 

--- a/rrule/src/parser/mod.rs
+++ b/rrule/src/parser/mod.rs
@@ -3,7 +3,7 @@
 mod content_line;
 mod datetime;
 mod error;
-mod regex;
+mod parsers;
 mod utils;
 
 use std::str::FromStr;


### PR DESCRIPTION
This PR removes both the `regex` and `lazy_static` as direct dependencies. This mainly  to decrease the binary size.

In release mode, with stripped binary (x86_64), a simple RRuleSet parse example is decreased with ~1.1 MiB compared to when build before this PR.
I haven't measured how it compares performance wise.