### PR TITLE
RRuleSetIter: removed lifetimes and added from_str example

### DIFF
--- a/rrule/examples/manual_iter.rs
+++ b/rrule/examples/manual_iter.rs
@@ -13,6 +13,15 @@ fn main() {
 
     let iter = rrule.into_iter();
 
+    // Or:
+    //
+    // let iter: RRuleSetIter = "DTSTART;TZID=America/New_York:20200902T130000\n\
+    //      RRULE:FREQ=Weekly"
+    //      .parse()
+    //      .expect("The RRule is not valid");
+    //
+
+
     for next in iter.take(50) {
         if next.year() == 2021 {
             println!("These are all the weeks before 2021.");
@@ -20,4 +29,5 @@ fn main() {
         }
         println!("Date: {}", next.to_rfc3339());
     }
+
 }

--- a/rrule/examples/manual_iter.rs
+++ b/rrule/examples/manual_iter.rs
@@ -21,7 +21,6 @@ fn main() {
     //      .expect("The RRule is not valid");
     //
 
-
     for next in iter.take(50) {
         if next.year() == 2021 {
             println!("These are all the weeks before 2021.");
@@ -29,5 +28,4 @@ fn main() {
         }
         println!("Date: {}", next.to_rfc3339());
     }
-
 }

--- a/rrule/src/iter/iterinfo.rs
+++ b/rrule/src/iter/iterinfo.rs
@@ -7,21 +7,21 @@ use crate::{Frequency, NWeekday, RRule};
 use chrono::{Datelike, NaiveTime, TimeZone};
 
 #[derive(Debug, Clone)]
-pub(crate) struct IterInfo<'a> {
+pub(crate) struct IterInfo {
     year_info: YearInfo,
     month_info: Option<MonthInfo>,
     easter_mask: Option<Vec<i32>>,
-    rrule: &'a RRule,
+    rrule: RRule,
 }
 
-impl<'a> IterInfo<'a> {
-    pub fn new(rrule: &'a RRule, dt_start: &DateTime) -> Self {
+impl IterInfo {
+    pub fn new(rrule: &RRule, dt_start: &DateTime) -> Self {
         let year = dt_start.year();
         let month = get_month(dt_start);
 
         let year_info = YearInfo::new(year, rrule);
         let mut ii = Self {
-            rrule,
+            rrule: rrule.clone(),
             year_info,
             month_info: None,
             easter_mask: None,
@@ -35,7 +35,7 @@ impl<'a> IterInfo<'a> {
         if !skip_year_info
             && !matches!(&self.month_info, Some(month_info) if month_info.last_year == year)
         {
-            self.year_info = YearInfo::new(year, self.rrule);
+            self.year_info = YearInfo::new(year, &self.rrule);
         }
 
         let contains_nth_by_weekday = self
@@ -47,7 +47,7 @@ impl<'a> IterInfo<'a> {
         if contains_nth_by_weekday
             && !(matches!(&self.month_info, Some(month_info) if month_info.last_month == month && month_info.last_year == year))
         {
-            let new_month_info = MonthInfo::new(&self.year_info, month, self.rrule);
+            let new_month_info = MonthInfo::new(&self.year_info, month, &self.rrule);
             self.month_info = Some(new_month_info);
         }
 
@@ -269,6 +269,6 @@ impl<'a> IterInfo<'a> {
     }
 
     pub fn rrule(&self) -> &RRule {
-        self.rrule
+        &self.rrule
     }
 }

--- a/rrule/src/iter/rrule_iter.rs
+++ b/rrule/src/iter/rrule_iter.rs
@@ -8,10 +8,10 @@ use chrono::{NaiveTime, TimeZone};
 use std::collections::VecDeque;
 
 #[derive(Debug, Clone)]
-pub(crate) struct RRuleIter<'a> {
+pub(crate) struct RRuleIter {
     /// Date the iterator is currently at.
     pub(crate) counter_date: DateTimeIter,
-    pub(crate) ii: IterInfo<'a>,
+    pub(crate) ii: IterInfo,
     pub(crate) timeset: Vec<NaiveTime>,
     pub(crate) dt_start: DateTime,
     /// Buffer of datetimes is not yet yielded
@@ -28,8 +28,8 @@ pub(crate) struct RRuleIter<'a> {
     pub(crate) was_limited: bool,
 }
 
-impl<'a> RRuleIter<'a> {
-    pub(crate) fn new(rrule: &'a RRule, dt_start: &DateTime, limited: bool) -> Self {
+impl RRuleIter {
+    pub(crate) fn new(rrule: &RRule, dt_start: &DateTime, limited: bool) -> Self {
         let ii = IterInfo::new(rrule, dt_start);
 
         let hour = get_hour(dt_start);
@@ -204,7 +204,7 @@ impl<'a> RRuleIter<'a> {
     }
 }
 
-impl<'a> Iterator for RRuleIter<'a> {
+impl Iterator for RRuleIter {
     type Item = DateTime;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -229,7 +229,7 @@ pub(crate) trait WasLimited {
     fn was_limited(&self) -> bool;
 }
 
-impl<'a> WasLimited for RRuleIter<'a> {
+impl WasLimited for RRuleIter {
     fn was_limited(&self) -> bool {
         self.was_limited
     }

--- a/rrule/src/iter/rruleset_iter.rs
+++ b/rrule/src/iter/rruleset_iter.rs
@@ -1,23 +1,25 @@
 use super::rrule_iter::WasLimited;
 use super::{rrule_iter::RRuleIter, MAX_ITER_LOOP};
+use crate::RRuleError;
 use crate::{core::DateTime, RRuleSet};
 use std::collections::BTreeSet;
+use std::str::FromStr;
 use std::{collections::HashMap, iter::Iterator};
 
 #[derive(Debug, Clone)]
 /// Iterator over all the dates in an [`RRuleSet`].
-pub struct RRuleSetIter<'a> {
+pub struct RRuleSetIter {
     queue: HashMap<usize, DateTime>,
     limited: bool,
-    rrule_iters: Vec<RRuleIter<'a>>,
-    exrules: Vec<RRuleIter<'a>>,
+    rrule_iters: Vec<RRuleIter>,
+    exrules: Vec<RRuleIter>,
     exdates: BTreeSet<i64>,
     /// Sorted additional dates in descending order
     rdates: Vec<DateTime>,
     was_limited: bool,
 }
 
-impl<'a> RRuleSetIter<'a> {
+impl RRuleSetIter {
     fn generate_date(
         dates: &mut Vec<DateTime>,
         exrules: &mut [RRuleIter],
@@ -104,7 +106,7 @@ impl<'a> RRuleSetIter<'a> {
     }
 }
 
-impl<'a> Iterator for RRuleSetIter<'a> {
+impl Iterator for RRuleSetIter {
     type Item = DateTime;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -191,10 +193,10 @@ impl<'a> Iterator for RRuleSetIter<'a> {
     }
 }
 
-impl<'a> IntoIterator for &'a RRuleSet {
+impl IntoIterator for &RRuleSet {
     type Item = DateTime;
 
-    type IntoIter = RRuleSetIter<'a>;
+    type IntoIter = RRuleSetIter;
 
     fn into_iter(self) -> Self::IntoIter {
         // Sort in decreasing order
@@ -224,8 +226,16 @@ impl<'a> IntoIterator for &'a RRuleSet {
     }
 }
 
-impl<'a> WasLimited for RRuleSetIter<'a> {
+impl WasLimited for RRuleSetIter {
     fn was_limited(&self) -> bool {
         self.was_limited
+    }
+}
+
+impl FromStr for RRuleSetIter {
+    type Err = RRuleError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(RRuleSet::from_str(s)?.into_iter())
     }
 }


### PR DESCRIPTION
This is just between a feature and a fix.

In my use-case, i have to store a `RRuleSetIter` inside an object up to keep the current state of the iterator and not recreate the iterator again and again

Therefore, it was not possible due to the lifetime of  `RRuleSetIter`, currently :

```rust
pub struct Recurrent<'a> {
    rrule_iter: RRuleSetIter<'a>,
}

impl<'a> FromStr for Recurrent<'a> {
    type Err = RRuleError;

    fn from_str(s: &str) -> Result<Self, Self::Err> {
        let rrule = s.parse::<RRuleSet>()?;
        let iter: RRuleSetIter<'a> = rrule.into_iter();
        return Ok(Self {
            rrule_iter: iter,
        });
    }
}
 
```
Gives this error :

```rust
error[E0597]: `rrule` does not live long enough
  --> src/programs/module/recurrent.rs:17:38
   |
12 | impl<'a> FromStr for Recurrent<'a> {
   |      -- lifetime `'a` defined here
...
16 |         let rrule = s.parse::<RRuleSet>()?;
   |             ----- binding `rrule` declared here
17 |         let iter: RRuleSetIter<'a> = rrule.into_iter();
   |                   ----------------   ^^^^^ borrowed value does not live long enough
   |                   |
   |                   type annotation requires that `rrule` is borrowed for `'a`
18 |         return Ok(Self { rrule_iter: iter });
19 |     }
   |     - `rrule` dropped here while still borrowed
```

So, I removed the lifetimes, and the only real change is the in the struct `IterInfo` where the field rrule have to be a value and not a reference, and it has to be cloned on `IterInfo::new`.

Since it is also possible now, I implemented `FromStr` for  `RRuleSetIter` in addition.

