### PR TITLE
bump dependencies and remove use of deprecated types

### DIFF
--- a/rrule/Cargo.toml
+++ b/rrule/Cargo.toml
@@ -14,17 +14,17 @@ edition.workspace = true
 
 [dependencies]
 chrono = "0.4.19"
-chrono-tz = "0.8.1"
+chrono-tz = "0.9.0"
 lazy_static = "1.4.0"
 log = "0.4.16"
 regex = { version = "1.5.5", default-features = false, features = ["perf", "std"] }
 clap = { version = "4.1.9", optional = true, features = ["derive"] }
 thiserror = "1.0.30"
-serde_with = { version = "2.3.1", optional = true }
+serde_with = { version = "3.8.1", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0.80"
-orig_serde = { package = "serde", version = "1.0.137", default-features = false }
+orig_serde = { package = "serde", version = "1.0.137", default-features = false, features = ["derive"]}
 
 [[bin]]
 name = "rrule"

--- a/rrule/src/iter/pos_list.rs
+++ b/rrule/src/iter/pos_list.rs
@@ -1,4 +1,4 @@
-use super::utils::{add_time_to_date, from_ordinal, pymod};
+use super::utils::{add_time_to_date, date_from_ordinal, pymod};
 use crate::core::{DateTime, Tz};
 use chrono::NaiveTime;
 
@@ -44,13 +44,12 @@ pub(crate) fn build_pos_list(
         let day = i64::try_from(*day)
             .expect("dayset is controlled by us and all elements are within range of i64");
 
-        // Get ordinal which is UTC and apply timezone
-        let date = from_ordinal(year_ordinal + day).date().with_timezone(&tz);
+        // Get ordinal which is UTC
+        let date = date_from_ordinal(year_ordinal + day);
         // Create new Date + Time combination
-        // Use Date and Timezone from `date`
         // Use Time from `timeset`.
         let time = timeset[time_pos];
-        let res = match add_time_to_date(date, time) {
+        let res = match add_time_to_date(tz, date, time) {
             Some(date) => date,
             None => continue,
         };

--- a/rrule/src/iter/rrule_iter.rs
+++ b/rrule/src/iter/rrule_iter.rs
@@ -1,10 +1,9 @@
 use super::counter_date::DateTimeIter;
 use super::utils::add_time_to_date;
-use super::{build_pos_list, utils::from_ordinal, IterInfo, MAX_ITER_LOOP};
+use super::{build_pos_list, utils::date_from_ordinal, IterInfo, MAX_ITER_LOOP};
 use crate::core::{get_hour, get_minute, get_second};
 use crate::{core::DateTime, Frequency, RRule};
-use chrono::Datelike;
-use chrono::{NaiveTime, TimeZone};
+use chrono::NaiveTime;
 use std::collections::VecDeque;
 
 #[derive(Debug, Clone)]
@@ -124,6 +123,8 @@ impl<'a> RRuleIter<'a> {
                 self.counter_date.day,
             );
 
+            let tz = self.dt_start.timezone();
+
             if rrule.by_set_pos.is_empty() {
                 // Loop over `start..end`
                 for current_day in &dayset {
@@ -133,17 +134,10 @@ impl<'a> RRuleIter<'a> {
                     let year_ordinal = self.ii.year_ordinal();
                     // Ordinal conversion uses UTC: if we apply local-TZ here, then
                     // just below we'll end up double-applying.
-                    let date = from_ordinal(year_ordinal + current_day);
-                    // We apply the local-TZ here.
-                    let date = self
-                        .dt_start
-                        .timezone()
-                        .ymd(date.year(), date.month(), date.day());
-
+                    let date = date_from_ordinal(year_ordinal + current_day);
                     for time in &self.timeset {
-                        let dt = match add_time_to_date(date, *time) {
-                            Some(dt) => dt,
-                            None => continue,
+                        let Some(dt) = add_time_to_date(tz, date, *time) else {
+                            continue;
                         };
                         if Self::try_add_datetime(
                             dt,

--- a/rrule/src/parser/datetime.rs
+++ b/rrule/src/parser/datetime.rs
@@ -59,7 +59,8 @@ pub(crate) fn datestring_to_date(
     // For more info https://icalendar.org/iCalendar-RFC-5545/3-3-5-date-time.html
     let datetime: chrono::DateTime<Tz> = if flags.zulu_timezone_set {
         // If a `Z` is present, UTC should be used.
-        chrono::DateTime::<chrono::Utc>::from_utc(datetime, chrono::Utc).with_timezone(&Tz::UTC)
+        chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(datetime, chrono::Utc)
+            .with_timezone(&Tz::UTC)
     } else {
         // If no `Z` is present, local time should be used.
         use chrono::offset::LocalResult;


### PR DESCRIPTION
Bump dependencies chrono-tz and serde_with. Also remove use of deprecated chrono types and functions to decrease the number of compile time warnings.

Edit: added missing feature "derive" to serde.