### PR TITLE
use NaiveDate where appropriate

### DIFF
--- a/rrule/src/iter/counter_date.rs
+++ b/rrule/src/iter/counter_date.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use chrono::{Datelike, TimeZone, Timelike, Utc, Weekday};
+use chrono::{Datelike, NaiveDate, Timelike, Weekday};
 
 use crate::{Frequency, RRule, RRuleError, Tz};
 
@@ -90,8 +90,7 @@ impl DateTimeIter {
         };
         let year_day = u32::from(month_range_mask[self.month as usize - 1]) + self.day - 1;
         let year_day_mod = year_day % 7;
-        let year_start_weekday = Utc
-            .with_ymd_and_hms(self.year, 1, 1, 0, 0, 0)
+        let year_start_weekday = NaiveDate::from_ymd_opt(self.year, 1, 1)
             // It should never fail, since there is always a 1st of January, is there?
             .unwrap()
             .weekday()

--- a/rrule/src/iter/iterinfo.rs
+++ b/rrule/src/iter/iterinfo.rs
@@ -4,7 +4,7 @@ use super::easter::easter;
 use super::{monthinfo::MonthInfo, yearinfo::YearInfo};
 use crate::core::get_month;
 use crate::{Frequency, NWeekday, RRule, Tz};
-use chrono::{Datelike, NaiveTime, TimeZone};
+use chrono::{Datelike, NaiveDate, NaiveTime};
 
 #[derive(Debug, Clone)]
 pub(crate) struct IterInfo {
@@ -69,7 +69,7 @@ impl IterInfo {
         self.year_info.year_len
     }
 
-    pub fn year_ordinal(&self) -> i64 {
+    pub fn year_ordinal(&self) -> i32 {
         self.year_info.year_ordinal
     }
 
@@ -126,8 +126,7 @@ impl IterInfo {
         let set_len = usize::from(self.year_len() + 7);
 
         let mut date_ordinal = usize::try_from(
-            chrono::Utc
-                .with_ymd_and_hms(year, month, day, 0, 0, 0)
+            NaiveDate::from_ymd_opt(year, month, day)
                 .unwrap()
                 .ordinal0(),
         )
@@ -152,11 +151,9 @@ impl IterInfo {
     }
 
     pub fn day_dayset(year: i32, month: u32, day: u32) -> Vec<usize> {
-        let date_ordinal = chrono::Utc
-            .with_ymd_and_hms(year, month, day, 0, 0, 0)
+        let date_ordinal = NaiveDate::from_ymd_opt(year, month, day)
             .unwrap()
             .ordinal0();
-
         vec![usize::try_from(date_ordinal).expect("target arch should have at least 32 bits")]
     }
 

--- a/rrule/src/iter/pos_list.rs
+++ b/rrule/src/iter/pos_list.rs
@@ -6,7 +6,7 @@ pub(crate) fn build_pos_list(
     by_set_pos: &[i32],
     dayset: &[usize],
     timeset: &[NaiveTime],
-    year_ordinal: i64,
+    year_ordinal: i32,
     tz: Tz,
 ) -> Vec<chrono::DateTime<Tz>> {
     let mut pos_list = vec![];
@@ -41,8 +41,8 @@ pub(crate) fn build_pos_list(
             Some(day) => day,
             None => continue,
         };
-        let day = i64::try_from(*day)
-            .expect("dayset is controlled by us and all elements are within range of i64");
+        let day = i32::try_from(*day)
+            .expect("dayset is controlled by us and all elements are within range of i32");
 
         // Get ordinal which is UTC
         let date = date_from_ordinal(year_ordinal + day);

--- a/rrule/src/iter/rrule_iter.rs
+++ b/rrule/src/iter/rrule_iter.rs
@@ -128,8 +128,8 @@ impl RRuleIter {
             if rrule.by_set_pos.is_empty() {
                 // Loop over `start..end`
                 for current_day in &dayset {
-                    let current_day = i64::try_from(*current_day).expect(
-                        "We control the dayset, and we know that it will always fit within an i64",
+                    let current_day = i32::try_from(*current_day).expect(
+                        "We control the dayset, and we know that it will always fit within i32",
                     );
                     let year_ordinal = self.ii.year_ordinal();
                     // Ordinal conversion uses UTC: if we apply local-TZ here, then

--- a/rrule/src/iter/utils.rs
+++ b/rrule/src/iter/utils.rs
@@ -1,20 +1,18 @@
 use std::ops;
 
 use crate::core::{duration_from_midnight, Tz};
-use chrono::{NaiveDate, NaiveTime, Utc};
+use chrono::{Datelike, NaiveDate, NaiveTime};
 
-const DAY_SECS: i64 = 24 * 60 * 60;
+const UNIX_EPOCH_DAY: i32 = 719_163;
 
 /// Converts number of days since unix epoch to a (naive) date.
-pub(crate) fn date_from_ordinal(ordinal: i64) -> NaiveDate {
-    chrono::DateTime::<Utc>::from_timestamp(ordinal * DAY_SECS, 0)
-        .unwrap()
-        .date_naive()
+pub(crate) fn date_from_ordinal(ordinal: i32) -> NaiveDate {
+    NaiveDate::from_num_days_from_ce_opt(UNIX_EPOCH_DAY + ordinal).unwrap()
 }
 
 /// Returns number of days since unix epoch (rounded down)
-pub(crate) fn days_since_unix_epoch(date: &chrono::DateTime<Utc>) -> i64 {
-    date.timestamp() / DAY_SECS
+pub(crate) fn days_since_unix_epoch(date: &NaiveDate) -> i32 {
+    date.num_days_from_ce() - UNIX_EPOCH_DAY
 }
 
 /// Returns true if given year is a leap year

--- a/rrule/src/iter/yearinfo.rs
+++ b/rrule/src/iter/yearinfo.rs
@@ -3,7 +3,7 @@ use super::{
     utils::{days_since_unix_epoch, get_year_len, pymod},
 };
 use crate::RRule;
-use chrono::{Datelike, TimeZone, Utc};
+use chrono::{Datelike, NaiveDate};
 
 #[derive(Debug)]
 pub(crate) struct BaseMasks {
@@ -43,7 +43,7 @@ pub(crate) struct YearInfo {
     /// Number of days in the next year (365 or 366)
     pub next_year_len: u16,
     /// Number of days since Unix epoch
-    pub year_ordinal: i64,
+    pub year_ordinal: i32,
     pub month_mask: &'static [u8],
     pub month_day_mask: &'static [i8],
     pub neg_month_day_mask: &'static [i8],
@@ -56,7 +56,7 @@ pub(crate) struct YearInfo {
 impl YearInfo {
     pub fn new(year: i32, rrule: &RRule) -> Self {
         // It should never fail, since there is always a 1st of January, is there?
-        let first_year_day = Utc.with_ymd_and_hms(year, 1, 1, 0, 0, 0).unwrap();
+        let first_year_day = NaiveDate::from_ymd_opt(year, 1, 1).unwrap();
 
         let year_len = get_year_len(year);
         let next_year_len = get_year_len(year + 1);
@@ -167,7 +167,7 @@ impl YearInfo {
                 -1
             } else {
                 let l_year_weekday = u16::try_from(
-                    Utc.with_ymd_and_hms(year - 1, 1, 1, 0, 0, 0)
+                    NaiveDate::from_ymd_opt(year - 1, 1, 1)
                         // It should never fail, since there is always a 1st of January, is there?
                         .unwrap()
                         .weekday()


### PR DESCRIPTION
Replace some DateTime<UTC>'s, where only the date part is needed, with NaiveDate. And use i32 for ordinal year since chronos year range seems to be limited to i32.