### PR TITLE
simplifications and out-of-memory fix in RRuleIterSet

### DIFF
--- a/rrule/src/tests/rruleset.rs
+++ b/rrule/src/tests/rruleset.rs
@@ -326,6 +326,98 @@ fn between() {
 }
 
 #[test]
+#[cfg(feature = "exrule")]
+fn multiple_rrules_and_exclude_1st() {
+    let dt_start = ymd_hms(1997, 9, 2, 9, 0, 0);
+
+    let rrule1 = RRule {
+        freq: Frequency::Yearly,
+        by_month: vec![9],
+        by_hour: vec![9],
+        by_minute: vec![0],
+        by_second: vec![0],
+        by_month_day: vec![2],
+        ..Default::default()
+    };
+
+    let rrule2 = RRule {
+        by_month_day: vec![1],
+        ..rrule1.clone()
+    }
+    .validate(dt_start)
+    .unwrap();
+
+    let rrule1 = rrule1.validate(dt_start).unwrap();
+
+    let set_exluding_rrule1 = RRuleSet::new(dt_start)
+        .rrule(rrule1.clone())
+        .rrule(rrule2.clone())
+        .exrule(rrule1.clone());
+
+    check_occurrences(
+        &set_exluding_rrule1.all(10).dates,
+        &[
+            "1998-09-01T09:00:00+00:00",
+            "1999-09-01T09:00:00+00:00",
+            "2000-09-01T09:00:00+00:00",
+            "2001-09-01T09:00:00+00:00",
+            "2002-09-01T09:00:00+00:00",
+            "2003-09-01T09:00:00+00:00",
+            "2004-09-01T09:00:00+00:00",
+            "2005-09-01T09:00:00+00:00",
+            "2006-09-01T09:00:00+00:00",
+            "2007-09-01T09:00:00+00:00",
+        ],
+    );
+}
+
+#[test]
+#[cfg(feature = "exrule")]
+fn multiple_rrules_and_exclude_2nd() {
+    let dt_start = ymd_hms(1997, 9, 2, 9, 0, 0);
+
+    let rrule1 = RRule {
+        freq: Frequency::Yearly,
+        by_month: vec![9],
+        by_hour: vec![9],
+        by_minute: vec![0],
+        by_second: vec![0],
+        by_month_day: vec![2],
+        ..Default::default()
+    };
+
+    let rrule2 = RRule {
+        by_month_day: vec![1],
+        ..rrule1.clone()
+    }
+    .validate(dt_start)
+    .unwrap();
+
+    let rrule1 = rrule1.validate(dt_start).unwrap();
+
+    let set_exluding_rrule2 = RRuleSet::new(dt_start)
+        .rrule(rrule1)
+        .rrule(rrule2.clone())
+        .exrule(rrule2);
+
+    check_occurrences(
+        &set_exluding_rrule2.all(10).dates,
+        &[
+            "1997-09-02T09:00:00+00:00",
+            "1998-09-02T09:00:00+00:00",
+            "1999-09-02T09:00:00+00:00",
+            "2000-09-02T09:00:00+00:00",
+            "2001-09-02T09:00:00+00:00",
+            "2002-09-02T09:00:00+00:00",
+            "2003-09-02T09:00:00+00:00",
+            "2004-09-02T09:00:00+00:00",
+            "2005-09-02T09:00:00+00:00",
+            "2006-09-02T09:00:00+00:00",
+        ],
+    );
+}
+
+#[test]
 fn before_70s() {
     let dt_start = ymd_hms(1960, 1, 1, 9, 0, 0);
 


### PR DESCRIPTION
...and another one :1234: 

Did some simplifications to the RRuleSetIter, mainly trying to get rid of the HashMap queue thing.

Following to this change it seemed possible to stop appending exrules dates to the exdates btree indefinitely (which eventually may cause out of memory on the system). And instead keeping track of the last value of each iterator. A change made possible since the date given to the `is_date_excluded` should now always be greater (or the same) as the last call to the function. Hence there is no need to track previously yielded exrule dates.

These changes seems to improve the overall iteration performance of the RRuleSetIter. I have created some benchmarks (not in PR) and the iteration time is cut down by 4-70 % depending on the specific rruleset tested.


