### PR TITLE
Drop alias Datetime; use chrono::Datetime

### DIFF
--- a/rrule/src/core/datetime.rs
+++ b/rrule/src/core/datetime.rs
@@ -1,38 +1,36 @@
 use super::timezone::Tz;
 use chrono::{Datelike, Duration, NaiveTime, Timelike};
 
-pub(crate) type DateTime = chrono::DateTime<Tz>;
-
 pub(crate) fn duration_from_midnight(time: NaiveTime) -> Duration {
     Duration::hours(i64::from(time.hour()))
         + Duration::minutes(i64::from(time.minute()))
         + Duration::seconds(i64::from(time.second()))
 }
 
-pub(crate) fn get_month(dt: &DateTime) -> u8 {
+pub(crate) fn get_month(dt: &chrono::DateTime<Tz>) -> u8 {
     u8::try_from(dt.month()).expect("month is between 1-12 which is covered by u8")
 }
 
-pub(crate) fn get_day(dt: &DateTime) -> i8 {
+pub(crate) fn get_day(dt: &chrono::DateTime<Tz>) -> i8 {
     i8::try_from(dt.day()).expect("day is between 1-31 which is covered by i8")
 }
 
-pub(crate) fn get_hour(dt: &DateTime) -> u8 {
+pub(crate) fn get_hour(dt: &chrono::DateTime<Tz>) -> u8 {
     u8::try_from(dt.hour()).expect("hour is between 0-23 which is covered by u8")
 }
 
-pub(crate) fn get_minute(dt: &DateTime) -> u8 {
+pub(crate) fn get_minute(dt: &chrono::DateTime<Tz>) -> u8 {
     u8::try_from(dt.minute()).expect("minute is between 0-59 which is covered by u8")
 }
 
-pub(crate) fn get_second(dt: &DateTime) -> u8 {
+pub(crate) fn get_second(dt: &chrono::DateTime<Tz>) -> u8 {
     u8::try_from(dt.second()).expect("second is between 0-59 which is covered by u8")
 }
 
 /// Generates an iCalendar date-time string format with the prefix symbols.
 /// Like: `:19970714T173000Z` or `;TZID=America/New_York:19970714T133000`
 /// ref: <https://tools.ietf.org/html/rfc5545#section-3.3.5>
-pub(crate) fn datetime_to_ical_format(dt: &DateTime) -> String {
+pub(crate) fn datetime_to_ical_format(dt: &chrono::DateTime<Tz>) -> String {
     let mut tz_prefix = String::new();
     let mut tz_postfix = String::new();
     let tz = dt.timezone();

--- a/rrule/src/core/mod.rs
+++ b/rrule/src/core/mod.rs
@@ -8,7 +8,7 @@ pub(crate) mod utils;
 pub use self::rrule::{Frequency, NWeekday, RRule};
 pub use self::rruleset::{RRuleResult, RRuleSet};
 pub(crate) use datetime::{
-    duration_from_midnight, get_day, get_hour, get_minute, get_month, get_second, DateTime,
+    duration_from_midnight, get_day, get_hour, get_minute, get_month, get_second,
 };
 pub use timezone::Tz;
 

--- a/rrule/src/core/rruleset.rs
+++ b/rrule/src/core/rruleset.rs
@@ -1,8 +1,8 @@
 use crate::core::datetime::datetime_to_ical_format;
 use crate::core::utils::collect_with_error;
-use crate::core::DateTime;
 use crate::parser::{ContentLine, Grammar};
-use crate::{ParseError, RRule, RRuleError};
+use crate::{ParseError, RRule, RRuleError, Tz};
+use chrono::DateTime;
 #[cfg(feature = "serde")]
 use serde_with::{serde_as, DeserializeFromStr, SerializeDisplay};
 use std::fmt::Display;
@@ -16,17 +16,17 @@ pub struct RRuleSet {
     /// List of rrules.
     pub(crate) rrule: Vec<RRule>,
     /// List of rdates.
-    pub(crate) rdate: Vec<DateTime>,
+    pub(crate) rdate: Vec<DateTime<Tz>>,
     /// List of exules.
     pub(crate) exrule: Vec<RRule>,
     /// List of exdates.
-    pub(crate) exdate: Vec<DateTime>,
+    pub(crate) exdate: Vec<DateTime<Tz>>,
     /// The start datetime of the recurring event.
-    pub(crate) dt_start: DateTime,
+    pub(crate) dt_start: DateTime<Tz>,
     /// If set, all returned recurrences must be before this date.
-    pub(crate) before: Option<DateTime>,
+    pub(crate) before: Option<DateTime<Tz>>,
     /// If set, all returned recurrences must be after this date.
-    pub(crate) after: Option<DateTime>,
+    pub(crate) after: Option<DateTime<Tz>>,
     /// If validation limits are enabled
     pub(crate) limited: bool,
 }
@@ -35,7 +35,7 @@ pub struct RRuleSet {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RRuleResult {
     /// List of recurrences.
-    pub dates: Vec<DateTime>,
+    pub dates: Vec<DateTime<Tz>>,
     /// It is being true if the list of dates is limited.
     /// To indicate that it can potentially contain more dates.
     pub limited: bool,
@@ -44,7 +44,7 @@ pub struct RRuleResult {
 impl RRuleSet {
     /// Creates an empty [`RRuleSet`], starting from `ds_start`.
     #[must_use]
-    pub fn new(dt_start: DateTime) -> Self {
+    pub fn new(dt_start: DateTime<Tz>) -> Self {
         Self {
             dt_start,
             rrule: vec![],
@@ -70,7 +70,7 @@ impl RRuleSet {
     ///
     /// This value will not be used if you use the `Iterator` API directly.
     #[must_use]
-    pub fn before(mut self, dt: DateTime) -> Self {
+    pub fn before(mut self, dt: DateTime<Tz>) -> Self {
         self.before = Some(dt);
         self
     }
@@ -79,7 +79,7 @@ impl RRuleSet {
     ///
     /// This value will not be used if you use the `Iterator` API directly.
     #[must_use]
-    pub fn after(mut self, dt: DateTime) -> Self {
+    pub fn after(mut self, dt: DateTime<Tz>) -> Self {
         self.after = Some(dt);
         self
     }
@@ -101,14 +101,14 @@ impl RRuleSet {
 
     /// Adds a new rdate to the set.
     #[must_use]
-    pub fn rdate(mut self, rdate: DateTime) -> Self {
+    pub fn rdate(mut self, rdate: DateTime<Tz>) -> Self {
         self.rdate.push(rdate);
         self
     }
 
     /// Adds a new exdate to the set.
     #[must_use]
-    pub fn exdate(mut self, exdate: DateTime) -> Self {
+    pub fn exdate(mut self, exdate: DateTime<Tz>) -> Self {
         self.exdate.push(exdate);
         self
     }
@@ -130,14 +130,14 @@ impl RRuleSet {
 
     /// Sets the rdates of the set.
     #[must_use]
-    pub fn set_rdates(mut self, rdates: Vec<DateTime>) -> Self {
+    pub fn set_rdates(mut self, rdates: Vec<DateTime<Tz>>) -> Self {
         self.rdate = rdates;
         self
     }
 
     /// Set the exdates of the set.
     #[must_use]
-    pub fn set_exdates(mut self, exdates: Vec<DateTime>) -> Self {
+    pub fn set_exdates(mut self, exdates: Vec<DateTime<Tz>>) -> Self {
         self.exdate = exdates;
         self
     }
@@ -156,19 +156,19 @@ impl RRuleSet {
 
     /// Returns the rdates of the set.
     #[must_use]
-    pub fn get_rdate(&self) -> &Vec<DateTime> {
+    pub fn get_rdate(&self) -> &Vec<DateTime<Tz>> {
         &self.rdate
     }
 
     /// Returns the exdates of the set.
     #[must_use]
-    pub fn get_exdate(&self) -> &Vec<DateTime> {
+    pub fn get_exdate(&self) -> &Vec<DateTime<Tz>> {
         &self.exdate
     }
 
     /// Returns the start datetime of the recurring event.
     #[must_use]
-    pub fn get_dt_start(&self) -> &DateTime {
+    pub fn get_dt_start(&self) -> &DateTime<Tz> {
         &self.dt_start
     }
 
@@ -208,7 +208,7 @@ impl RRuleSet {
     /// This method does not enforce any validation limits and might lead to
     /// very long iteration times. Please read the `SECURITY.md` for more information.
     #[must_use]
-    pub fn all_unchecked(self) -> Vec<DateTime> {
+    pub fn all_unchecked(self) -> Vec<DateTime<Tz>> {
         collect_with_error(self.into_iter(), &self.after, &self.before, true, None).dates
     }
 

--- a/rrule/src/core/utils.rs
+++ b/rrule/src/core/utils.rs
@@ -1,6 +1,5 @@
-use super::DateTime;
-use crate::iter::rrule_iter::WasLimited;
 use crate::RRuleResult;
+use crate::{iter::rrule_iter::WasLimited, Tz};
 use std::ops::{
     Bound::{Excluded, Unbounded},
     RangeBounds,
@@ -12,13 +11,13 @@ use std::ops::{
 /// otherwise the second value of the return tuple will be `None`.
 pub(super) fn collect_with_error<T>(
     mut iterator: T,
-    start: &Option<DateTime>,
-    end: &Option<DateTime>,
+    start: &Option<chrono::DateTime<Tz>>,
+    end: &Option<chrono::DateTime<Tz>>,
     inclusive: bool,
     limit: Option<u16>,
 ) -> RRuleResult
 where
-    T: Iterator<Item = DateTime> + WasLimited,
+    T: Iterator<Item = chrono::DateTime<Tz>> + WasLimited,
 {
     let mut list = vec![];
     let mut was_limited = false;
@@ -48,7 +47,11 @@ where
 }
 
 /// Checks if `date` is after `end`.
-fn has_reached_the_end(date: &DateTime, end: &Option<DateTime>, inclusive: bool) -> bool {
+fn has_reached_the_end(
+    date: &chrono::DateTime<Tz>,
+    end: &Option<chrono::DateTime<Tz>>,
+    inclusive: bool,
+) -> bool {
     if inclusive {
         match end {
             Some(end) => !(..=end).contains(&date),
@@ -64,9 +67,9 @@ fn has_reached_the_end(date: &DateTime, end: &Option<DateTime>, inclusive: bool)
 
 /// Helper function to determine if a date is within a given range.
 pub(super) fn is_in_range(
-    date: &DateTime,
-    start: &Option<DateTime>,
-    end: &Option<DateTime>,
+    date: &chrono::DateTime<Tz>,
+    start: &Option<chrono::DateTime<Tz>>,
+    end: &Option<chrono::DateTime<Tz>>,
     inclusive: bool,
 ) -> bool {
     // Should it include or not include the start and/or end date?

--- a/rrule/src/iter/counter_date.rs
+++ b/rrule/src/iter/counter_date.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use chrono::{Datelike, TimeZone, Timelike, Utc, Weekday};
 
-use crate::{core::DateTime, Frequency, RRule, RRuleError};
+use crate::{Frequency, RRule, RRuleError, Tz};
 
 use super::{
     checks,
@@ -305,8 +305,8 @@ impl DateTimeIter {
     }
 }
 
-impl From<&DateTime> for DateTimeIter {
-    fn from(dt: &DateTime) -> Self {
+impl From<&chrono::DateTime<Tz>> for DateTimeIter {
+    fn from(dt: &chrono::DateTime<Tz>) -> Self {
         Self {
             year: dt.year(),
             month: dt.month(),

--- a/rrule/src/iter/iterinfo.rs
+++ b/rrule/src/iter/iterinfo.rs
@@ -2,8 +2,8 @@ use super::counter_date::DateTimeIter;
 #[cfg(feature = "by-easter")]
 use super::easter::easter;
 use super::{monthinfo::MonthInfo, yearinfo::YearInfo};
-use crate::core::{get_month, DateTime};
-use crate::{Frequency, NWeekday, RRule};
+use crate::core::get_month;
+use crate::{Frequency, NWeekday, RRule, Tz};
 use chrono::{Datelike, NaiveTime, TimeZone};
 
 #[derive(Debug, Clone)]
@@ -15,7 +15,7 @@ pub(crate) struct IterInfo {
 }
 
 impl IterInfo {
-    pub fn new(rrule: &RRule, dt_start: &DateTime) -> Self {
+    pub fn new(rrule: &RRule, dt_start: &chrono::DateTime<Tz>) -> Self {
         let year = dt_start.year();
         let month = get_month(dt_start);
 

--- a/rrule/src/iter/pos_list.rs
+++ b/rrule/src/iter/pos_list.rs
@@ -1,5 +1,5 @@
 use super::utils::{add_time_to_date, date_from_ordinal, pymod};
-use crate::core::{DateTime, Tz};
+use crate::core::Tz;
 use chrono::NaiveTime;
 
 pub(crate) fn build_pos_list(
@@ -8,7 +8,7 @@ pub(crate) fn build_pos_list(
     timeset: &[NaiveTime],
     year_ordinal: i64,
     tz: Tz,
-) -> Vec<DateTime> {
+) -> Vec<chrono::DateTime<Tz>> {
     let mut pos_list = vec![];
 
     if timeset.is_empty() {

--- a/rrule/src/iter/rruleset_iter.rs
+++ b/rrule/src/iter/rruleset_iter.rs
@@ -1,7 +1,9 @@
+use chrono::DateTime;
+
 use super::rrule_iter::WasLimited;
 use super::{rrule_iter::RRuleIter, MAX_ITER_LOOP};
-use crate::RRuleError;
-use crate::{core::DateTime, RRuleSet};
+use crate::RRuleSet;
+use crate::{RRuleError, Tz};
 use std::collections::BTreeSet;
 use std::str::FromStr;
 use std::{collections::HashMap, iter::Iterator};
@@ -9,23 +11,23 @@ use std::{collections::HashMap, iter::Iterator};
 #[derive(Debug, Clone)]
 /// Iterator over all the dates in an [`RRuleSet`].
 pub struct RRuleSetIter {
-    queue: HashMap<usize, DateTime>,
+    queue: HashMap<usize, DateTime<Tz>>,
     limited: bool,
     rrule_iters: Vec<RRuleIter>,
     exrules: Vec<RRuleIter>,
     exdates: BTreeSet<i64>,
     /// Sorted additional dates in descending order
-    rdates: Vec<DateTime>,
+    rdates: Vec<DateTime<Tz>>,
     was_limited: bool,
 }
 
 impl RRuleSetIter {
     fn generate_date(
-        dates: &mut Vec<DateTime>,
+        dates: &mut Vec<DateTime<Tz>>,
         exrules: &mut [RRuleIter],
         exdates: &mut BTreeSet<i64>,
         limited: bool,
-    ) -> (Option<DateTime>, bool) {
+    ) -> (Option<DateTime<Tz>>, bool) {
         if dates.is_empty() {
             return (None, false);
         }
@@ -59,7 +61,7 @@ impl RRuleSetIter {
         exrules: &mut [RRuleIter],
         exdates: &mut BTreeSet<i64>,
         limited: bool,
-    ) -> (Option<DateTime>, bool) {
+    ) -> (Option<DateTime<Tz>>, bool) {
         let mut date = match rrule_iter.next() {
             Some(d) => d,
             None => return (None, false),
@@ -89,7 +91,7 @@ impl RRuleSetIter {
     }
 
     fn is_date_excluded(
-        date: &DateTime,
+        date: &DateTime<Tz>,
         exrules: &mut [RRuleIter],
         exdates: &mut BTreeSet<i64>,
     ) -> bool {
@@ -107,10 +109,10 @@ impl RRuleSetIter {
 }
 
 impl Iterator for RRuleSetIter {
-    type Item = DateTime;
+    type Item = DateTime<Tz>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let mut next_date: Option<(usize, DateTime)> = None;
+        let mut next_date: Option<(usize, DateTime<Tz>)> = None;
 
         // If there already was an error, return the error again.
         if self.was_limited {
@@ -194,7 +196,7 @@ impl Iterator for RRuleSetIter {
 }
 
 impl IntoIterator for &RRuleSet {
-    type Item = DateTime;
+    type Item = DateTime<Tz>;
 
     type IntoIter = RRuleSetIter;
 

--- a/rrule/src/iter/utils.rs
+++ b/rrule/src/iter/utils.rs
@@ -1,6 +1,6 @@
 use std::ops;
 
-use crate::core::{duration_from_midnight, DateTime, Tz};
+use crate::core::{duration_from_midnight, Tz};
 use chrono::{NaiveDate, NaiveTime, Utc};
 
 const DAY_SECS: i64 = 24 * 60 * 60;
@@ -72,7 +72,11 @@ where
     }
 }
 
-pub(crate) fn add_time_to_date(tz: Tz, date: NaiveDate, time: NaiveTime) -> Option<DateTime> {
+pub(crate) fn add_time_to_date(
+    tz: Tz,
+    date: NaiveDate,
+    time: NaiveTime,
+) -> Option<chrono::DateTime<Tz>> {
     if let Some(dt) = date.and_time(time).and_local_timezone(tz).single() {
         return Some(dt);
     }

--- a/rrule/src/parser/content_line/date_content_line.rs
+++ b/rrule/src/parser/content_line/date_content_line.rs
@@ -3,11 +3,11 @@ use std::{collections::HashMap, str::FromStr};
 use log::warn;
 
 use crate::{
-    core::DateTime,
     parser::{
         datetime::{datestring_to_date, parse_timezone},
         ParseError,
     },
+    Tz,
 };
 
 use super::{content_line_parts::ContentLineCaptures, parameters::parse_parameters};
@@ -31,7 +31,7 @@ impl FromStr for DateParameter {
     }
 }
 
-impl<'a> TryFrom<ContentLineCaptures<'a>> for Vec<DateTime> {
+impl<'a> TryFrom<ContentLineCaptures<'a>> for Vec<chrono::DateTime<Tz>> {
     type Error = ParseError;
 
     fn try_from(value: ContentLineCaptures) -> Result<Self, Self::Error> {

--- a/rrule/src/parser/content_line/mod.rs
+++ b/rrule/src/parser/content_line/mod.rs
@@ -7,8 +7,8 @@ mod start_date_content_line;
 use std::fmt::Display;
 use std::str::FromStr;
 
-use crate::core::DateTime;
 use crate::RRule;
+use crate::Tz;
 use crate::Unvalidated;
 
 pub(crate) use content_line_parts::ContentLineCaptures;
@@ -20,8 +20,8 @@ use super::ParseError;
 pub(crate) enum ContentLine {
     RRule(RRule<Unvalidated>),
     ExRule(RRule<Unvalidated>),
-    ExDate(Vec<DateTime>),
-    RDate(Vec<DateTime>),
+    ExDate(Vec<chrono::DateTime<Tz>>),
+    RDate(Vec<chrono::DateTime<Tz>>),
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]

--- a/rrule/src/parser/content_line/start_date_content_line.rs
+++ b/rrule/src/parser/content_line/start_date_content_line.rs
@@ -5,7 +5,7 @@ use super::{
     parameters::parse_parameters,
 };
 use crate::{
-    core::{DateTime, Tz},
+    core::Tz,
     parser::{
         datetime::{datestring_to_date, parse_timezone},
         ParseError,
@@ -16,7 +16,7 @@ const UTC: Tz = Tz::UTC;
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct StartDateContentLine {
-    pub datetime: DateTime,
+    pub datetime: chrono::DateTime<Tz>,
     pub timezone: Option<Tz>,
     pub value: &'static str,
 }

--- a/rrule/src/parser/datetime.rs
+++ b/rrule/src/parser/datetime.rs
@@ -1,10 +1,7 @@
 use std::str::FromStr;
 
 use super::{regex::ParsedDateString, ParseError};
-use crate::{
-    core::{DateTime, Tz},
-    NWeekday,
-};
+use crate::{core::Tz, NWeekday};
 use chrono::{NaiveDate, TimeZone, Weekday};
 
 /// Attempts to convert a `str` to a `chrono_tz::Tz`.
@@ -21,7 +18,7 @@ pub(crate) fn datestring_to_date(
     dt: &str,
     tz: Option<Tz>,
     property: &str,
-) -> Result<DateTime, ParseError> {
+) -> Result<chrono::DateTime<Tz>, ParseError> {
     let ParsedDateString {
         year,
         month,

--- a/rrule/src/tests/common.rs
+++ b/rrule/src/tests/common.rs
@@ -78,7 +78,7 @@ pub fn check_occurrences<S: AsRef<str> + Debug>(occurrences: &[DateTime<Tz>], ex
     );
     assert_eq!(occurrences.len(), expected.len(), "List sizes don't match");
     for (given, expected) in occurrences.iter().zip(expected.iter()) {
-        let exp_datetime = chrono::DateTime::parse_from_rfc3339(expected.as_ref()).unwrap();
+        let exp_datetime = DateTime::parse_from_rfc3339(expected.as_ref()).unwrap();
         // Compare items and check if in the same offset/timezone
         assert_eq!(
             given.to_rfc3339(),


### PR DESCRIPTION
This is mostly in preparation for https://github.com/fmeringdal/rust-rrule/issues/24

A lot of these functions will continue taking a `DateTime<Tz>` as parameter, but other will allow a generic `Timezone` as parameter.