### PR TITLE
Remove `lazy_static` dependency in favor of `std` `OnceLock`

### DIFF
--- a/rrule/Cargo.toml
+++ b/rrule/Cargo.toml
@@ -15,7 +15,6 @@ edition.workspace = true
 [dependencies]
 chrono = "0.4.39"
 chrono-tz = "0.10.1"
-lazy_static = "1.4.0"
 log = "0.4.25"
 regex = { version = "1.11.1", default-features = false, features = ["perf", "std"] }
 clap = { version = "4.5.26", optional = true, features = ["derive"] }

--- a/rrule/src/parser/regex.rs
+++ b/rrule/src/parser/regex.rs
@@ -92,7 +92,7 @@ pub(crate) fn get_property_name(val: &str) -> Result<Option<PropertyName>, Parse
 
     PARSE_PROPERTY_NAME_RE
         .get_or_init(|| {
-            Regex::new(r"(?m)^([A-Z]+?)[:;]").expect("PARSE_PROPERTY_NAME_RE regex failed")
+            Regex::new(r"(?m)^([A-Z]+?)[:;]").expect("PARSE_PROPERTY_NAME_RE regex must compile")
         })
         .captures(val)
         .and_then(|captures| captures.get(1))

--- a/rrule/src/parser/regex.rs
+++ b/rrule/src/parser/regex.rs
@@ -51,7 +51,7 @@ impl ParsedDateString {
                 Regex::new(
                     r"(?m)^([0-9]{4})([0-9]{2})([0-9]{2})(T([0-9]{2})([0-9]{2})([0-9]{2})(Z?))?$",
                 )
-                .expect("DATESTR_RE regex failed")
+                .expect("DATESTR_RE must compile")
             })
             .captures(val)
             .ok_or_else(|| ParseError::InvalidDateTimeFormat(val.into()))?;


### PR DESCRIPTION
The MSRV of this crate is higher than 1.70, which introduced `std::sync::OnceLock`, a type which can act as a similarly ergonomic replacement for the `lazy_static` and `once_cell` crates. Pulling the least dependencies is always welcome by users of a library such as `rrule`, so let's replace uses of `lazy_lock` with `OnceLock`.