### PR TITLE
Update dependencies to their latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         - { name: macOS, os: macos-latest, triple: x86_64-apple-darwin }
         - { name: Windows, os: windows-2022, triple: x86_64-pc-windows-msvc }
         version:
-        - 1.74.0 # MSRV
+        - 1.81.0 # MSRV
         - stable
     steps:
       - uses: actions/checkout@v2

--- a/rrule-afl-fuzz/Cargo.toml
+++ b/rrule-afl-fuzz/Cargo.toml
@@ -11,8 +11,8 @@ rust-version.workspace = true
 
 [dependencies]
 afl = "*"
-chrono = "0.4.19"
-num-traits = "0.2.15"
+chrono = "0.4.39"
+num-traits = "0.2.19"
 
 [dependencies.rrule]
 path = "../rrule"

--- a/rrule-debugger/Cargo.toml
+++ b/rrule-debugger/Cargo.toml
@@ -11,11 +11,11 @@ rust-version.workspace = true
 
 [dependencies]
 rrule = { path = "../rrule" }
-chrono = "0.4.19"
-clap = { version = "4.1.9", features = ["derive"] }
+chrono = "0.4.39"
+clap = { version = "4.5.26", features = ["derive"] }
 rrule-afl-fuzz = { version = "0.1.0", path = "../rrule-afl-fuzz" }
-log = "0.4.16"
-yansi = "0.5.1"
+log = "0.4.25"
+yansi = "1.0.1"
 
 [features]
 default = []

--- a/rrule-debugger/src/simple_logger.rs
+++ b/rrule-debugger/src/simple_logger.rs
@@ -37,7 +37,7 @@ impl log::Log for Logger {
                     Level::Debug => Paint::green("DEBUG"),
                     Level::Trace => Paint::magenta("TRACE"),
                 },
-                Paint::new(record.target()).dimmed(),
+                Paint::new(record.target()).dim(),
                 record.args()
             );
         }

--- a/rrule/Cargo.toml
+++ b/rrule/Cargo.toml
@@ -13,18 +13,18 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
-chrono = "0.4.19"
-chrono-tz = "0.9.0"
+chrono = "0.4.39"
+chrono-tz = "0.10.1"
 lazy_static = "1.4.0"
-log = "0.4.16"
-regex = { version = "1.5.5", default-features = false, features = ["perf", "std"] }
-clap = { version = "4.1.9", optional = true, features = ["derive"] }
-thiserror = "1.0.30"
-serde_with = { version = "3.8.1", optional = true }
+log = "0.4.25"
+regex = { version = "1.11.1", default-features = false, features = ["perf", "std"] }
+clap = { version = "4.5.26", optional = true, features = ["derive"] }
+thiserror = "2.0.11"
+serde_with = { version = "3.12.0", optional = true }
 
 [dev-dependencies]
-serde_json = "1.0.80"
-orig_serde = { package = "serde", version = "1.0.137", default-features = false, features = ["derive"]}
+serde_json = "1.0.135"
+orig_serde = { package = "serde", version = "1.0.217", default-features = false, features = ["derive"] }
 
 [[bin]]
 name = "rrule"


### PR DESCRIPTION
This is specially relevant for users that try to combine `chrono-tz` v0.10.x with `rrule`, as otherwise several versions of `chrono-tz` can be pulled into a project, which is both inefficient (could cause two sets of timezone information to be embedded in the resulting binaries) and confusing (different `chrono-tz` versions have different versions of the same types, which makes it more cumbersome to interoperate with `rrule`).

MSRV was bumped to 1.81 because the latest version of `home`, a transitive build dependency pulled by `afl`, requires that Rust version.