### PR TITLE
feat: add dst-fold-first feature for handling ambiguous DST times

### DIFF
--- a/rrule/Cargo.toml
+++ b/rrule/Cargo.toml
@@ -43,3 +43,7 @@ serde = ["serde_with", "chrono/serde", "chrono-tz/serde"]
 
 # Allows EXRULE's to be used in the `RRuleSet`.
 exrule = []
+
+# When a datetime is ambiguous due to daylight saving time transitions,
+# pick the first (earliest) occurrence instead of returning an error.
+dst-fold-first = []

--- a/rrule/src/iter/utils.rs
+++ b/rrule/src/iter/utils.rs
@@ -77,8 +77,11 @@ pub(crate) fn add_time_to_date(
     date: NaiveDate,
     time: NaiveTime,
 ) -> Option<chrono::DateTime<Tz>> {
-    if let Some(dt) = date.and_time(time).and_local_timezone(tz).single() {
-        return Some(dt);
+    match date.and_time(time).and_local_timezone(tz) {
+        chrono::offset::LocalResult::Single(dt) => return Some(dt),
+        #[cfg(feature = "dst-fold-first")]
+        chrono::offset::LocalResult::Ambiguous(dt, _) => return Some(dt),
+        _ => {}
     }
     // If the day is a daylight saving time, the above code might not work, and we
     // can try to get a valid datetime by adding the `time` as a duration instead.

--- a/rrule/src/parser/datetime.rs
+++ b/rrule/src/parser/datetime.rs
@@ -71,12 +71,15 @@ pub(crate) fn datestring_to_date(
                     property: property.into(),
                 }),
                 LocalResult::Single(date) => Ok(date),
-                LocalResult::Ambiguous(date1, date2) => {
+                LocalResult::Ambiguous(date1, _date2) => {
+                    #[cfg(feature = "dst-fold-first")]
+                    return Ok(date1);
+                    #[cfg(not(feature = "dst-fold-first"))]
                     Err(ParseError::DateTimeInLocalTimezoneIsAmbiguous {
                         value: dt.into(),
                         property: property.into(),
                         date1: date1.to_rfc3339(),
-                        date2: date2.to_rfc3339(),
+                        date2: _date2.to_rfc3339(),
                     })
                 }
             }?
@@ -89,16 +92,19 @@ pub(crate) fn datestring_to_date(
                     return Err(ParseError::InvalidDateTimeInLocalTimezone {
                         value: dt.into(),
                         property: property.into(),
-                    })
+                    });
                 }
                 LocalResult::Single(date) => date,
-                LocalResult::Ambiguous(date1, date2) => {
+                LocalResult::Ambiguous(date1, _date2) => {
+                    #[cfg(feature = "dst-fold-first")]
+                    return Ok(date1);
+                    #[cfg(not(feature = "dst-fold-first"))]
                     return Err(ParseError::DateTimeInLocalTimezoneIsAmbiguous {
                         value: dt.into(),
                         property: property.into(),
                         date1: date1.to_rfc3339(),
-                        date2: date2.to_rfc3339(),
-                    })
+                        date2: _date2.to_rfc3339(),
+                    });
                 }
             }
         }


### PR DESCRIPTION
Add a new feature flag 'dst-fold-first' that changes the behavior when encountering ambiguous local times during DST transitions.

Behavior:
- Without feature: Returns error for ambiguous DST times
- With feature enabled: Picks the first (earlier) occurrence

Implementation:
- parser/datetime.rs: Handle Ambiguous LocalResult by selecting first datetime
- iter/utils.rs: Handle Ambiguous LocalResult in add_time_to_date function

Tests (America/Mexico_City 2021-2022 DST transitions):
- dst_ambiguous_time_returns_error: Verifies error without feature
- dst_fold_first_picks_earlier_time: Verifies first (-05:00) is selected
- dst_fold_first_mexico_city_yearly: Tests yearly recurrence across DST

Note: Only affects 'Ambiguous' LocalResult (fall back overlap), not 'None' (spring forward gap). Mexico eliminated DST after 2022.

Usage:
  cargo build --features dst-fold-first